### PR TITLE
Refine compact app headers

### DIFF
--- a/__tests__/components/organisms/common/Header.test.tsx
+++ b/__tests__/components/organisms/common/Header.test.tsx
@@ -140,6 +140,40 @@ describe('Header', () => {
     expect(getByTestId('header-right-actions')).toBeTruthy();
   });
 
+  it('renders a slim gradient bar with the tab-name title and right actions', () => {
+    const { getByTestId, getByText } = renderWithProviders(
+      <Header
+        testID="slim-gradient-header"
+        variant="gradient"
+        slim
+        title="Create"
+        rightElement={<Text testID="header-right-actions">Actions</Text>}
+      />
+    );
+
+    expect(getByTestId('header-slim-row')).toBeTruthy();
+    expect(getByText('Create')).toBeTruthy();
+    expect(getByTestId('header-right-actions')).toBeTruthy();
+    expect(getByTestId('slim-gradient-header')).toHaveStyle({ minHeight: 52 });
+  });
+
+  it('renders a slim gradient bar with only the right actions, no greeting', () => {
+    const { getByTestId, queryByText } = renderWithProviders(
+      <Header
+        testID="slim-gradient-header"
+        variant="gradient"
+        slim
+        rightElement={<Text testID="header-right-actions">Actions</Text>}
+      />
+    );
+
+    expect(getByTestId('header-slim-row')).toBeTruthy();
+    expect(getByTestId('header-right-actions')).toBeTruthy();
+    // The greeting is moved to the body, so the slim bar shows no greeting text.
+    expect(queryByText('The symposium awaits')).toBeNull();
+    expect(getByTestId('slim-gradient-header')).toHaveStyle({ minHeight: 52 });
+  });
+
   it('keeps standard phone gradient headers compact', () => {
     const { getByTestId } = renderWithProviders(
       <Header

--- a/__tests__/components/organisms/debate/AudienceQuestionsModal.test.tsx
+++ b/__tests__/components/organisms/debate/AudienceQuestionsModal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
-import { ScrollView } from 'react-native';
+import { KeyboardAvoidingView, ScrollView, StyleSheet } from 'react-native';
 import { AudienceQuestionsModal } from '@/components/organisms/debate/AudienceQuestionsModal';
 import { renderWithProviders } from '../../../../test-utils/renderWithProviders';
 
@@ -50,6 +50,24 @@ describe('AudienceQuestionsModal', () => {
 
     expect(scrollView.props.contentContainerStyle).toContainEqual(
       expect.objectContaining({ paddingBottom: 62 })
+    );
+  });
+
+  it('keeps the keyboard-avoiding container full height so the sheet can lift above the keyboard', () => {
+    const { UNSAFE_getByType } = renderWithProviders(
+      <AudienceQuestionsModal
+        visible
+        onSubmit={jest.fn()}
+      />
+    );
+
+    const keyboardAvoidingView = UNSAFE_getByType(KeyboardAvoidingView);
+
+    expect(StyleSheet.flatten(keyboardAvoidingView.props.style)).toEqual(
+      expect.objectContaining({
+        flex: 1,
+        justifyContent: 'flex-end',
+      })
     );
   });
 });

--- a/__tests__/components/organisms/home/DynamicAISelector.test.tsx
+++ b/__tests__/components/organisms/home/DynamicAISelector.test.tsx
@@ -113,6 +113,27 @@ describe('DynamicAISelector', () => {
     expect(queryByText(/Start Chat/)).toBeNull();
   });
 
+  it('can hide the section title while keeping configured count and add action', () => {
+    const onAddAI = jest.fn();
+    const { getByText, queryByText } = renderWithProviders(
+      <DynamicAISelector
+        configuredAIs={aiList}
+        selectedAIs={[]}
+        maxAIs={3}
+        onToggleAI={jest.fn()}
+        onAddAI={onAddAI}
+        hideHeaderTitle
+        hideStartButton
+      />
+    );
+
+    expect(queryByText('Choose Your AIs')).toBeNull();
+    expect(getByText('2 AIs configured • Select up to 3')).toBeTruthy();
+
+    fireEvent.press(getByText('+ Add AI'));
+    expect(onAddAI).toHaveBeenCalled();
+  });
+
   it('passes the effective selected model to card badges', () => {
     const getBadge = jest.fn((ai: AIConfig) => (
       ai.model === 'gpt-5.5' ? { text: 'Live Search' } : undefined

--- a/__tests__/screens/ChatScreen.test.tsx
+++ b/__tests__/screens/ChatScreen.test.tsx
@@ -393,7 +393,7 @@ describe('ChatScreen', () => {
     );
 
     expect(getByTestId('chat-message-list')).toBeTruthy();
-    expect(mockHeaderProps.title).toBe('AI Conversation');
+    expect(mockHeaderProps.title).toBe('Conversation');
     expect(mockHeaderProps.subtitle).toBe('Claude meets GPT-4');
 
     fireEvent.press(getByTestId('header-back'));

--- a/__tests__/screens/CreateScreen.test.tsx
+++ b/__tests__/screens/CreateScreen.test.tsx
@@ -77,6 +77,13 @@ jest.mock('expo-haptics', () => ({
   NotificationFeedbackType: { Success: 'success', Error: 'error' },
 }));
 
+jest.mock('@/hooks/useGreeting', () => ({
+  useGreeting: () => ({
+    timeBasedGreeting: 'Pixels in the void',
+    welcomeMessage: 'Your pixels specifically',
+  }),
+}));
+
 jest.mock('expo-media-library', () => ({
   getPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted', granted: true }),
   requestPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
@@ -351,7 +358,8 @@ describe('CreateScreen', () => {
       );
 
       const { getByText } = renderWithProviders(<CreateScreen />);
-      expect(getByText('No generated media yet')).toBeTruthy();
+      // Empty gallery now shows the witty greeting (relocated from the header).
+      expect(getByText('Pixels in the void')).toBeTruthy();
     });
 
     it('selects a focused generated media item when Gallery is opened from completion', async () => {

--- a/__tests__/screens/HistoryScreen.test.tsx
+++ b/__tests__/screens/HistoryScreen.test.tsx
@@ -377,7 +377,7 @@ describe('HistoryScreen', () => {
   it('shows loading skeleton when history is loading', () => {
     renderHistoryScreen({ history: { isLoading: true } });
 
-    expect(mockHeaderProps.title).toBe('History');
+    expect(mockHeaderProps.title).toBe('The Archives');
     expect(mockHistoryListProps).toBeUndefined();
   });
 

--- a/__tests__/screens/HistoryScreen.test.tsx
+++ b/__tests__/screens/HistoryScreen.test.tsx
@@ -377,7 +377,7 @@ describe('HistoryScreen', () => {
   it('shows loading skeleton when history is loading', () => {
     renderHistoryScreen({ history: { isLoading: true } });
 
-    expect(mockHeaderProps.title).toBe('History awaits');
+    expect(mockHeaderProps.title).toBe('History');
     expect(mockHistoryListProps).toBeUndefined();
   });
 
@@ -397,62 +397,6 @@ describe('HistoryScreen', () => {
     });
 
     expect(sessionHistoryState.refresh).toHaveBeenCalledTimes(1);
-  });
-
-  it('clears all storage from the management menu and shows success toast', async () => {
-    mockClearAllSessions.mockResolvedValueOnce(undefined);
-    renderHistoryScreen();
-
-    expect(mockHeaderProps.actionButton.label).toBe('Manage');
-    await act(async () => {
-      mockHeaderProps.actionButton.onPress();
-    });
-
-    const [, , buttons] = alertSpy.mock.calls[0];
-    const clearAllButton = buttons.find((btn: any) => btn.text === 'Clear All');
-
-    await act(async () => {
-      clearAllButton.onPress();
-    });
-
-    const [, , confirmButtons] = alertSpy.mock.calls[1];
-    const destructiveButton = confirmButtons.find((btn: any) => btn.style === 'destructive');
-
-    await act(async () => {
-      await destructiveButton.onPress();
-    });
-
-    expect(mockClearAllSessions).toHaveBeenCalledTimes(1);
-    expect(sessionHistoryState.refresh).toHaveBeenCalled();
-    expect(mockShowSuccess).toHaveBeenCalledWith('All storage has been cleared.', 'history');
-  });
-
-  it('handles storage clear failures gracefully', async () => {
-    mockClearAllSessions.mockRejectedValueOnce(new Error('fail'));
-    renderHistoryScreen();
-
-    await act(async () => {
-      mockHeaderProps.actionButton.onPress();
-    });
-
-    const [, , buttons] = alertSpy.mock.calls[0];
-    const clearAllButton = buttons.find((btn: any) => btn.text === 'Clear All');
-
-    await act(async () => {
-      clearAllButton.onPress();
-    });
-
-    const [, , confirmButtons] = alertSpy.mock.calls[1];
-    const destructiveButton = confirmButtons.find((btn: any) => btn.style === 'destructive');
-
-    await act(async () => {
-      await destructiveButton.onPress();
-    });
-
-    expect(mockHandleWithToast).toHaveBeenCalledWith(
-      expect.any(Error),
-      expect.objectContaining({ feature: 'history' })
-    );
   });
 
   it('supports selecting visible history rows and bulk deleting them', async () => {
@@ -507,39 +451,13 @@ describe('HistoryScreen', () => {
     expect(mockHistoryListProps.selectedSessionIds.has('session-2')).toBe(true);
   });
 
-  it('selects visible sessions from the management menu', async () => {
-    const sessions = [
-      createSession({ id: 'session-1' }),
-      createSession({ id: 'session-2' }),
-    ];
-    renderHistoryScreen({
-      history: { sessions },
-      search: { filteredSessions: sessions },
-    });
-
-    await act(async () => {
-      mockHeaderProps.actionButton.onPress();
-    });
-
-    const [, , buttons] = alertSpy.mock.calls[0];
-    const selectVisibleButton = buttons.find((btn: any) => btn.text === 'Select Visible');
-
-    await act(async () => {
-      selectVisibleButton.onPress();
-    });
-
-    expect(mockHistoryListProps.selectionMode).toBe(true);
-    expect(mockHistoryListProps.selectedSessionIds.has('session-1')).toBe(true);
-    expect(mockHistoryListProps.selectedSessionIds.has('session-2')).toBe(true);
-  });
-
   it('shows demo indicators and dispatches subscription sheet', async () => {
     const store = createAppStore();
     const dispatchSpy = jest.spyOn(store, 'dispatch');
 
     renderHistoryScreen({ featureAccess: { isDemo: true }, store });
 
-    expect(mockHeaderProps.showDemoBadge).toBe(true);
+    // Demo is now indicated by the thin banner under the header, not a header chip.
     expect(mockDemoBannerProps.subtitle).toContain('Demo Mode');
 
     await act(async () => {
@@ -646,7 +564,11 @@ describe('HistoryScreen', () => {
     });
 
     expect(mockEmptyStateProps.type).toBe('no-sessions');
-    expect(mockEmptyStateProps.emptyStateConfig).toBeUndefined();
+    // The witty greeting is the title; the functional guidance is the message.
+    expect(mockEmptyStateProps.emptyStateConfig).toMatchObject({
+      title: 'History awaits',
+      message: 'Your past conversations',
+    });
 
     sessionSearchState.searchQuery = 'anthropic';
     sessionSearchState.filteredSessions = [];
@@ -657,12 +579,12 @@ describe('HistoryScreen', () => {
     expect(mockEmptyStateProps.type).toBe('no-results');
 
     await pressButton('Debate');
-    expect(mockEmptyStateProps.emptyStateConfig).toMatchObject({ title: 'No debates yet' });
+    expect(mockEmptyStateProps.emptyStateConfig).toMatchObject({ title: 'History awaits', message: 'Start a debate to see it here' });
 
     await pressButton('Compare');
-    expect(mockEmptyStateProps.emptyStateConfig).toMatchObject({ title: 'No comparisons yet' });
+    expect(mockEmptyStateProps.emptyStateConfig).toMatchObject({ title: 'History awaits', message: 'Compare AI responses to see them here' });
 
     await pressButton('Chat');
-    expect(mockEmptyStateProps.emptyStateConfig).toMatchObject({ title: 'No chats yet' });
+    expect(mockEmptyStateProps.emptyStateConfig).toMatchObject({ title: 'History awaits', message: 'Start a conversation to see it here' });
   });
 });

--- a/__tests__/screens/HomeScreen.test.tsx
+++ b/__tests__/screens/HomeScreen.test.tsx
@@ -238,13 +238,14 @@ const renderHome = (options?: { aiSelection?: ReturnType<typeof createAISelectio
 
     expect(mockUseAISelection).toHaveBeenCalledWith(premium.maxAIs);
     expect(mockHeaderProps).toBeDefined();
-    // The header is now a clean slim bar with the tab name; no greeting/demo badge.
+    // The header is now a clean slim bar with a task-oriented title; no greeting/demo badge.
     expect(mockHeaderProps.slim).toBe(true);
-    expect(mockHeaderProps.title).toBe('Chat');
+    expect(mockHeaderProps.title).toBe('Ask the Room');
     expect(mockHeaderActionsProps).toBeDefined();
     expect(mockHeaderActionsProps.variant).toBe('gradient');
     expect(mockHeaderActionsProps.helpCategoryId).toBe('chat');
     expect(mockDynamicAISelectorProps.maxAIs).toBe(aiSelection.maxAIs);
+    expect(mockDynamicAISelectorProps.hideHeaderTitle).toBe(true);
     // Quick Start is exposed through the trailing lightbulb on the primary button.
     expect(mockDynamicAISelectorProps.onQuickStart).toBeDefined();
   });

--- a/__tests__/screens/HomeScreen.test.tsx
+++ b/__tests__/screens/HomeScreen.test.tsx
@@ -238,9 +238,9 @@ const renderHome = (options?: { aiSelection?: ReturnType<typeof createAISelectio
 
     expect(mockUseAISelection).toHaveBeenCalledWith(premium.maxAIs);
     expect(mockHeaderProps).toBeDefined();
-    expect(mockHeaderProps.title).toBe(baseGreeting.timeBasedGreeting);
-    expect(mockHeaderProps.subtitle).toBe(baseGreeting.welcomeMessage);
-    expect(mockHeaderProps.showDemoBadge).toBe(false);
+    // The header is now a clean slim bar with the tab name; no greeting/demo badge.
+    expect(mockHeaderProps.slim).toBe(true);
+    expect(mockHeaderProps.title).toBe('Chat');
     expect(mockHeaderActionsProps).toBeDefined();
     expect(mockHeaderActionsProps.variant).toBe('gradient');
     expect(mockHeaderActionsProps.helpCategoryId).toBe('chat');

--- a/__tests__/screens/StatsScreen.test.tsx
+++ b/__tests__/screens/StatsScreen.test.tsx
@@ -185,7 +185,7 @@ describe('StatsScreen', () => {
     expect(mockHeader).toHaveBeenCalledWith(
       expect.objectContaining({
         variant: 'gradient',
-        title: 'AI Performance Stats',
+        title: 'Performance Stats',
         showBackButton: true,
         onBack: expect.any(Function),
       }),

--- a/src/components/organisms/chat/ChatTypingIndicators.tsx
+++ b/src/components/organisms/chat/ChatTypingIndicators.tsx
@@ -11,7 +11,7 @@ export interface TypingIndicatorProps {
 
 export const TypingIndicator: React.FC<TypingIndicatorProps> = ({ aiName }) => {
   const { theme } = useTheme();
-  
+
   return (
     <Animated.View
       entering={FadeIn}

--- a/src/components/organisms/common/Header.tsx
+++ b/src/components/organisms/common/Header.tsx
@@ -125,8 +125,10 @@ export interface HeaderProps {
   animationDelay?: number;
   
   // Content
-  title: string;
+  title?: string;
   subtitle?: string;
+  /** Slim gradient bar: renders only the right-side actions (no title/greeting). */
+  slim?: boolean;
   
   // Navigation
   onBack?: () => void;
@@ -176,6 +178,8 @@ const TABLET_GRADIENT_LONG_MOTION_EXTRA_HEIGHT = 16;
 const COMPACT_HEIGHT = 50;
 const TABLET_COMPACT_HEIGHT = 60;
 const GRADIENT_TOP_ROW_HEIGHT = 40;
+// Slim gradient bar (greeting moved into the scroll body): just holds the actions.
+const SLIM_GRADIENT_HEIGHT = 52;
 
 // Gradient header uses proportional scaling for tablets
 const MIN_TABLET_GRADIENT_HEIGHT = 100;
@@ -294,8 +298,9 @@ export const Header: React.FC<HeaderProps> = ({
   height,
   animated = false,
   animationDelay = 0,
-  title,
+  title = '',
   subtitle,
+  slim = false,
   onBack,
   showBackButton = false,
   rightElement,
@@ -422,7 +427,9 @@ export const Header: React.FC<HeaderProps> = ({
       theme.spacing.xs
     )
     : 0;
-  const headerHeight = height || Math.max(baseHeight, gradientContentMinimumHeight);
+  const isSlimGradient = variant === 'gradient' && slim;
+  const headerHeight = height
+    || (isSlimGradient ? SLIM_GRADIENT_HEIGHT : Math.max(baseHeight, gradientContentMinimumHeight));
   const totalHeight = headerHeight + insets.top;
   
   // Get variant-specific styles
@@ -858,7 +865,34 @@ export const Header: React.FC<HeaderProps> = ({
     >
       {renderBackground()}
       
-      {variant === 'gradient' ? (
+      {isSlimGradient ? (
+        /* Slim bar: only the right-side actions; the greeting lives in the body. */
+        <View
+          testID="header-slim-row"
+          style={[
+            styles.gradientSlimRow,
+            {
+              top: insets.top,
+              height: SLIM_GRADIENT_HEIGHT,
+              left: gradientHorizontalPadding,
+              right: gradientHorizontalPadding,
+            },
+          ]}
+        >
+          <View style={styles.gradientSlimLeft}>
+            {title ? (
+              <Typography variant="title" weight="bold" color="inverse" numberOfLines={1}>
+                {title}
+              </Typography>
+            ) : null}
+          </View>
+          {rightElement && (
+            <View style={styles.gradientTopRowRight}>
+              {rightElement}
+            </View>
+          )}
+        </View>
+      ) : variant === 'gradient' ? (
         <>
           {/* Gradient variant uses vertical layout structure */}
           {(gradientTopLeftContent || rightElement) && (
@@ -1066,6 +1100,19 @@ const createStyles = (
     alignItems: 'center',
     justifyContent: 'space-between',
     zIndex: 1000,
+  },
+  gradientSlimRow: {
+    position: 'absolute',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    zIndex: 1000,
+  },
+  gradientSlimLeft: {
+    flex: 1,
+    minWidth: 0,
+    alignItems: 'flex-start',
+    justifyContent: 'center',
   },
   gradientTopRowLeft: {
     flex: 1,

--- a/src/components/organisms/debate/AudienceQuestionsModal.tsx
+++ b/src/components/organisms/debate/AudienceQuestionsModal.tsx
@@ -150,6 +150,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0, 0, 0, 0.48)',
   },
   keyboardAvoidingView: {
+    flex: 1,
     justifyContent: 'flex-end',
   },
   sheet: {

--- a/src/components/organisms/home/DynamicAISelector.tsx
+++ b/src/components/organisms/home/DynamicAISelector.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, useWindowDimensions } from 'react-native';
+import { View, TouchableOpacity, useWindowDimensions } from 'react-native';
 import { Box } from '@/components/atoms';
 import { GradientButton, SectionHeader, InfoButton, Typography } from '@/components/molecules';
 import { AICard } from './AICard';
@@ -23,6 +23,7 @@ interface DynamicAISelectorProps {
   customSubtitle?: string;
   hideStartButton?: boolean;  // New prop to hide the start button
   hideHeader?: boolean;  // New prop to hide the section header
+  hideHeaderTitle?: boolean;  // Hide the title while keeping count/action row
   hideAddAI?: boolean;  // Hide "+ Add AI" button (for demo mode)
   columnCount?: number;  // New prop to override column count
   containerWidth?: number;  // New prop to override container width calculation
@@ -48,6 +49,7 @@ export const DynamicAISelector: React.FC<DynamicAISelectorProps> = ({
   customSubtitle,
   hideStartButton = false,
   hideHeader = false,
+  hideHeaderTitle = false,
   hideAddAI = false,
   columnCount,
   containerWidth,
@@ -96,7 +98,32 @@ export const DynamicAISelector: React.FC<DynamicAISelectorProps> = ({
   
   return (
     <Box>
-      {!hideHeader && (
+      {!hideHeader && (hideHeaderTitle ? (
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: theme.spacing.md,
+            gap: theme.spacing.sm,
+          }}
+        >
+          <Typography variant="body" color="secondary" style={{ flex: 1 }}>
+            {getSubtitle()}
+          </Typography>
+          {!hideAddAI && (
+            <TouchableOpacity
+              onPress={handleAddAI}
+              accessibilityRole="button"
+              accessibilityLabel="Add AI"
+            >
+              <Typography variant="body" color="primary" style={{ paddingHorizontal: theme.spacing.sm }}>
+                + Add AI
+              </Typography>
+            </TouchableOpacity>
+          )}
+        </View>
+      ) : (
         <SectionHeader
           title="Choose Your AIs"
           subtitle={getSubtitle()}
@@ -104,7 +131,7 @@ export const DynamicAISelector: React.FC<DynamicAISelectorProps> = ({
           onAction={hideAddAI ? undefined : handleAddAI}
           actionLabel={hideAddAI ? undefined : "+ Add AI"}
         />
-      )}
+      ))}
       
       {/* AI Grid Layout - Only AI cards, no Add button */}
       <View style={{ marginBottom: theme.spacing.lg, overflow: 'visible', zIndex: 1 }}>

--- a/src/components/organisms/profile/ProfileContent.tsx
+++ b/src/components/organisms/profile/ProfileContent.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { View, StyleSheet, ScrollView, Alert, Platform } from 'react-native';
+import { View, StyleSheet, ScrollView, Alert, Platform, KeyboardAvoidingView } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { useSelector, useDispatch } from 'react-redux';
@@ -159,7 +159,10 @@ export const ProfileContent: React.FC<ProfileContentProps> = ({
   if (!isAuthenticated) {
     if (showAuthForm) {
       return (
-        <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+        <KeyboardAvoidingView
+          style={[styles.container, { backgroundColor: theme.colors.background }]}
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        >
           <View style={styles.authHeader}>
             <Button
               title="← Back"
@@ -172,8 +175,11 @@ export const ProfileContent: React.FC<ProfileContentProps> = ({
             </Typography>
             <View style={{ width: 60 }} />
           </View>
-          
-          <ScrollView style={styles.authFormContainer}>
+
+          <ScrollView
+            style={styles.authFormContainer}
+            keyboardShouldPersistTaps="handled"
+          >
             <EmailAuthForm
               mode={authMode}
               onSubmit={handleEmailAuth}
@@ -191,7 +197,7 @@ export const ProfileContent: React.FC<ProfileContentProps> = ({
               />
             </View>
           </ScrollView>
-        </View>
+        </KeyboardAvoidingView>
       );
     }
     

--- a/src/screens/APIConfigScreen.tsx
+++ b/src/screens/APIConfigScreen.tsx
@@ -141,8 +141,8 @@ const APIConfigScreen: React.FC<APIConfigScreenProps> = ({ navigation }) => {
       <SafeAreaView style={{ flex: 1 }} edges={['left', 'right', 'bottom']}>
         <Header
           variant="gradient"
-          title="API Configuration"
-          subtitle="Add or Modify Your AIs"
+          title="Configure AIs"
+          subtitle="Add provider keys"
           onBack={() => {
             navigation.goBack();
             dispatch(showSheet({ sheet: 'settings' }));

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -498,7 +498,7 @@ const ChatScreen: React.FC<ChatScreenProps> = ({ navigation, route }) => {
         {/* Header */}
         <Header
           variant="gradient"
-          title="AI Conversation"
+          title="Conversation"
           subtitle={(() => {
             const aiNames = session.selectedAIs.map(ai => ai.name);
             const count = aiNames.length;

--- a/src/screens/CompareScreen.tsx
+++ b/src/screens/CompareScreen.tsx
@@ -1009,7 +1009,7 @@ const CompareScreen: React.FC<CompareScreenProps> = ({ navigation, route }) => {
       >
         <Header
           variant="gradient"
-          title="Comparing"
+          title="Comparison"
           subtitle={`${leftAI.name} vs ${rightAI.name}`}
           showTime={false}
           showDate={false}

--- a/src/screens/CompareSetupScreen.tsx
+++ b/src/screens/CompareSetupScreen.tsx
@@ -7,7 +7,6 @@ import { RootState, setAIPersonality, setAIModel, isApiKeyConfigured } from '../
 import { Box } from '../components/atoms';
 import { Typography, Button } from '../components/molecules';
 import { Header, HeaderActions, DynamicAISelector } from '../components/organisms';
-import { useGreeting } from '../hooks/useGreeting';
 import { getProviderDefaultModel, resolveProviderModelId } from '@/config/modelConfigs';
 
 import { useTheme } from '../theme';
@@ -38,7 +37,6 @@ const CompareSetupScreen: React.FC<CompareSetupScreenProps> = ({ navigation, rou
   const dispatch = useDispatch();
   const apiKeys = useSelector((state: RootState) => state.settings.apiKeys || {});
   const access = useFeatureAccess();
-  const greeting = useGreeting({ screenCategory: 'compare' });
   const expertMode = useSelector((state: RootState) => state.settings.expertMode || {});
   
   // Calculate half screen width for each selector
@@ -155,13 +153,9 @@ const CompareSetupScreen: React.FC<CompareSetupScreenProps> = ({ navigation, rou
     >
       <Header
         variant="gradient"
-        title={greeting.timeBasedGreeting}
-        subtitle={greeting.welcomeMessage}
-        showTime={true}
-        showDate={true}
-        animated={true}
+        slim
+        title="Compare"
         rightElement={<HeaderActions variant="gradient" helpTopicId="compare-mode" />}
-        showDemoBadge={access.isDemo}
       />
       <TrialBanner />
       {access.isDemo && (

--- a/src/screens/CompareSetupScreen.tsx
+++ b/src/screens/CompareSetupScreen.tsx
@@ -154,7 +154,7 @@ const CompareSetupScreen: React.FC<CompareSetupScreenProps> = ({ navigation, rou
       <Header
         variant="gradient"
         slim
-        title="Compare"
+        title="Spot the Difference"
         rightElement={<HeaderActions variant="gradient" helpTopicId="compare-mode" />}
       />
       <TrialBanner />

--- a/src/screens/CreateScreen.tsx
+++ b/src/screens/CreateScreen.tsx
@@ -89,6 +89,7 @@ import {
 import MediaSaveService from '../services/media/MediaSaveService';
 import { getMediaShareUti } from '../services/media/mediaFileCache';
 import useFeatureAccess from '../hooks/useFeatureAccess';
+import { useGreeting } from '../hooks/useGreeting';
 
 type NavigationProp = StackNavigationProp<RootStackParamList>;
 type ScreenRouteProp = RouteProp<RootStackParamList, 'CreateSession'>;
@@ -884,6 +885,7 @@ function buildFilterOptions(assets: GalleryAsset[], field: 'providerId' | 'model
 
 export default function CreateScreen() {
   const { theme, isDark } = useTheme();
+  const greeting = useGreeting({ screenCategory: 'create' });
   const insets = useSafeAreaInsets();
   const navigation = useNavigation<NavigationProp>();
   const route = useRoute<ScreenRouteProp>();
@@ -2152,7 +2154,7 @@ export default function CreateScreen() {
               color={theme.colors.text.secondary}
             />
             <Typography variant="body" color="secondary" style={styles.emptyText}>
-              {gallerySearch || activeFilterCount > 0 ? 'No matching assets' : 'No generated media yet'}
+              {gallerySearch || activeFilterCount > 0 ? 'No matching assets' : greeting.timeBasedGreeting}
             </Typography>
             {(gallerySearch || activeFilterCount > 0) && (
               <TouchableOpacity

--- a/src/screens/CreateSetupScreen.tsx
+++ b/src/screens/CreateSetupScreen.tsx
@@ -29,7 +29,6 @@ import Slider from '@react-native-community/slider';
 
 import { useTheme } from '../theme';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
-import { useGreeting } from '../hooks/useGreeting';
 import {
   Typography,
   GradientButton,
@@ -162,7 +161,6 @@ export default function CreateSetupScreen() {
   const navigation = useNavigation<NavigationProp>();
   const dispatch = useDispatch<AppDispatch>();
   const { isDemo } = useFeatureAccess();
-  const greeting = useGreeting({ screenCategory: 'create' });
 
   const createState = useSelector(selectCreateState);
   const apiKeys = useSelector((state: RootState) => state.settings.apiKeys || {});
@@ -2136,12 +2134,9 @@ export default function CreateSetupScreen() {
     >
       <Header
         variant="gradient"
-        title={greeting.timeBasedGreeting}
-        subtitle={greeting.welcomeMessage}
-        showTime={true}
-        showDate={true}
+        slim
+        title="Create"
         rightElement={renderHeaderRight()}
-        showDemoBadge={isDemo}
       />
       <KeyboardAvoidingView
         style={styles.flex}

--- a/src/screens/CreateSetupScreen.tsx
+++ b/src/screens/CreateSetupScreen.tsx
@@ -2096,8 +2096,8 @@ export default function CreateSetupScreen() {
       >
         <Header
           variant="gradient"
-          title="Create"
-          subtitle="Image, Video, and Audio Generation"
+          slim
+          title="Slop Central"
           rightElement={<HeaderActions variant="gradient" helpCategoryId="create" />}
         />
         <View style={styles.premiumGate}>
@@ -2135,7 +2135,7 @@ export default function CreateSetupScreen() {
       <Header
         variant="gradient"
         slim
-        title="Create"
+        title="Slop Central"
         rightElement={renderHeaderRight()}
       />
       <KeyboardAvoidingView

--- a/src/screens/DebateScreen.tsx
+++ b/src/screens/DebateScreen.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
-import { Alert, ActivityIndicator, Pressable, View } from 'react-native';
+import { Alert, ActivityIndicator, Pressable, View, KeyboardAvoidingView, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { ErrorService } from '@/services/errors/ErrorService';
@@ -632,36 +632,41 @@ const DebateScreen: React.FC<DebateScreenProps> = ({ navigation, route }) => {
     
     if (showTopicPicker) {
       return (
-        <Animated.View 
+        <Animated.View
           entering={FadeIn.duration(400)}
           layout={Layout.springify()}
           style={{ flex: 1 }}
         >
-          <DemoBanner
-            subtitle={canStartTrial
-              ? 'Pre-recorded debates only in Demo. Start a free trial to create custom debates.'
-              : 'Pre-recorded debates only in Demo. Upgrade to Premium to create custom debates.'}
-            onPress={() => dispatch(showSheet({ sheet: 'subscription' }))}
-          />
-          {isDemo && debateSamples.length > 0 && (
-            <DemoSamplesBar
-              label="Demo Debate Samples"
-              samples={debateSamples.map(s => ({ id: s.id, title: s.title }))}
-              onSelect={async (id) => {
-                try {
-                  const sample = await DemoContentService.findDebateById(id);
-                  if (!sample) return;
-                  selectedSampleRef.current = sample;
-                  // Start with sample's topic
-                  handleStartDebate(sample.topic);
-                } catch { /* ignore */ }
-              }}
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          >
+            <DemoBanner
+              subtitle={canStartTrial
+                ? 'Pre-recorded debates only in Demo. Start a free trial to create custom debates.'
+                : 'Pre-recorded debates only in Demo. Upgrade to Premium to create custom debates.'}
+              onPress={() => dispatch(showSheet({ sheet: 'subscription' }))}
             />
-          )}
-          <TopicSelector
-            {...topicSelection}
-            onStartDebate={handleStartDebate}
-          />
+            {isDemo && debateSamples.length > 0 && (
+              <DemoSamplesBar
+                label="Demo Debate Samples"
+                samples={debateSamples.map(s => ({ id: s.id, title: s.title }))}
+                onSelect={async (id) => {
+                  try {
+                    const sample = await DemoContentService.findDebateById(id);
+                    if (!sample) return;
+                    selectedSampleRef.current = sample;
+                    // Start with sample's topic
+                    handleStartDebate(sample.topic);
+                  } catch { /* ignore */ }
+                }}
+              />
+            )}
+            <TopicSelector
+              {...topicSelection}
+              onStartDebate={handleStartDebate}
+            />
+          </KeyboardAvoidingView>
         </Animated.View>
       );
     }

--- a/src/screens/DebateSetupScreen.tsx
+++ b/src/screens/DebateSetupScreen.tsx
@@ -902,6 +902,7 @@ const DebateSetupScreen: React.FC<DebateSetupScreenProps> = ({ navigation, route
           paddingBottom: rs('xl') * 3,
         }}
         showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
         onScroll={(event) => {
           currentScrollYRef.current = event.nativeEvent.contentOffset.y;
         }}

--- a/src/screens/DebateSetupScreen.tsx
+++ b/src/screens/DebateSetupScreen.tsx
@@ -9,7 +9,6 @@ import { Box, ResponsiveContainer } from '../components/atoms';
 import { Button, Typography, GradientButton, InfoButton } from '../components/molecules';
 import { useResponsive } from '../hooks/useResponsive';
 import { Header, HeaderActions } from '../components/organisms';
-import { useGreeting } from '../hooks/useGreeting';
 // Legacy premium gating replaced by useFeatureAccess
 import { useFeatureAccess } from '@/hooks/useFeatureAccess';
 import {
@@ -156,7 +155,6 @@ const DebateSetupScreen: React.FC<DebateSetupScreenProps> = ({ navigation, route
   const selectionReturnScrollYRef = useRef<number | null>(null);
   const handledResetKeyRef = useRef<string | null>(null);
   const { rs } = useResponsive();
-  const greeting = useGreeting({ screenCategory: 'debate' });
   const apiKeys = useSelector((state: RootState) => state.settings.apiKeys || {});
   const verifiedProviders = useSelector((state: RootState) => state.settings.verifiedProviders || []);
   const expertMode = useSelector((state: RootState) => state.settings.expertMode || {});
@@ -874,13 +872,9 @@ const DebateSetupScreen: React.FC<DebateSetupScreenProps> = ({ navigation, route
     <SafeAreaView style={{ flex: 1, backgroundColor: theme.colors.background }} edges={['left', 'right']}>
       <Header
         variant="gradient"
-        title={greeting.timeBasedGreeting}
-        subtitle={greeting.welcomeMessage}
-        showTime={true}
-        showDate={true}
-        animated={true}
+        slim
+        title="Debate"
         rightElement={<HeaderActions variant="gradient" helpTopicId="debate-formats" />}
-        showDemoBadge={access.isDemo}
       />
       <TrialBanner />
 

--- a/src/screens/DebateSetupScreen.tsx
+++ b/src/screens/DebateSetupScreen.tsx
@@ -873,7 +873,7 @@ const DebateSetupScreen: React.FC<DebateSetupScreenProps> = ({ navigation, route
       <Header
         variant="gradient"
         slim
-        title="Debate"
+        title="Settle an Argument"
         rightElement={<HeaderActions variant="gradient" helpTopicId="debate-formats" />}
       />
       <TrialBanner />

--- a/src/screens/ExpertModeScreen.tsx
+++ b/src/screens/ExpertModeScreen.tsx
@@ -37,8 +37,8 @@ const ExpertModeScreen: React.FC<{ navigation: { goBack: () => void } }> = ({ na
       <SafeAreaView style={{ flex: 1 }} edges={['left', 'right', 'bottom']}>
         <Header
           variant="gradient"
-          title="Expert Mode"
-          subtitle="Set Defaults & Parameters"
+          title="Model Defaults"
+          subtitle="Advanced parameters"
           onBack={() => {
             navigation.goBack();
             dispatch(showSheet({ sheet: 'settings' }));

--- a/src/screens/HistoryScreen.tsx
+++ b/src/screens/HistoryScreen.tsx
@@ -207,7 +207,7 @@ export const HistoryScreen: React.FC<HistoryScreenProps> = ({ navigation }) => {
             <Header
               variant="gradient"
               slim
-              title="History"
+              title="The Archives"
               rightElement={<HeaderActions variant="gradient" helpTopicId="history" />}
             />
 
@@ -399,7 +399,7 @@ export const HistoryScreen: React.FC<HistoryScreenProps> = ({ navigation }) => {
           <Header
             variant="gradient"
             slim
-            title="History"
+            title="The Archives"
             rightElement={<HeaderActions variant="gradient" helpTopicId="history" />}
           />
 

--- a/src/screens/HistoryScreen.tsx
+++ b/src/screens/HistoryScreen.tsx
@@ -1,13 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { ScrollView, View, Alert, StyleSheet } from 'react-native';
+import { ScrollView, View, StyleSheet } from 'react-native';
 import { Box } from '../components/atoms';
 import { Button, Typography } from '../components/molecules';
 import { useTheme } from '../theme';
 import { useGreeting } from '../hooks/useGreeting';
 import { useFocusEffect } from '@react-navigation/native';
-import { StorageService } from '../services/chat';
-import { ErrorService } from '@/services/errors/ErrorService';
 import {
   HistorySearchBar,
   HistoryList,
@@ -39,7 +37,7 @@ interface HistoryScreenProps {
 export const HistoryScreen: React.FC<HistoryScreenProps> = ({ navigation }) => {
   const { theme } = useTheme();
   const dispatch = useDispatch();
-  const { isDemo, canStartTrial } = useFeatureAccess();
+  const { canStartTrial } = useFeatureAccess();
   const { isTablet, isLandscape, width } = useResponsive();
   const greeting = useGreeting({ screenCategory: 'history' });
   const [activeTab, setActiveTab] = useState<'all' | 'chat' | 'comparison' | 'debate'>('all');
@@ -189,53 +187,6 @@ export const HistoryScreen: React.FC<HistoryScreenProps> = ({ navigation }) => {
     });
   }, [typeFilteredSessions]);
 
-  // Clear all storage function (for debugging)
-  const handleClearAllStorage = () => {
-    Alert.alert(
-      'Clear All Storage?',
-      'This will permanently delete ALL sessions from history. This action cannot be undone.',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Clear All',
-          style: 'destructive',
-          onPress: async () => {
-            try {
-              await StorageService.clearAllSessions();
-              refresh();
-              ErrorService.showSuccess('All storage has been cleared.', 'history');
-            } catch {
-              ErrorService.handleWithToast(new Error('Failed to clear storage.'), { feature: 'history' });
-            }
-          }
-        }
-      ]
-    );
-  };
-
-  const handleHistoryActions = () => {
-    Alert.alert(
-      'History Actions',
-      'Choose how to manage the current history view.',
-      [
-        {
-          text: 'Select Visible',
-          onPress: () => selectSessions(displaySessions),
-        },
-        {
-          text: 'Select All Matching',
-          onPress: () => selectSessions(typeFilteredSessions),
-        },
-        {
-          text: 'Clear All',
-          style: 'destructive',
-          onPress: handleClearAllStorage,
-        },
-        { text: 'Cancel', style: 'cancel' },
-      ]
-    );
-  };
-
   // Refresh sessions when screen comes into focus (tab navigation)
   useFocusEffect(
     React.useCallback(() => {
@@ -253,18 +204,21 @@ export const HistoryScreen: React.FC<HistoryScreenProps> = ({ navigation }) => {
       <SafeAreaView edges={['left', 'right']} style={{ flex: 1, backgroundColor: theme.colors.background }}>
         <ErrorBoundary>
           <Box style={{ flex: 1, backgroundColor: theme.colors.background }}>
-            {/* Header with greeting while loading */}
             <Header
               variant="gradient"
-              title={greeting.timeBasedGreeting}
-              subtitle="Loading your conversation archive..."
-              showTime={true}
-              showDate={true}
-              animated={true}
+              slim
+              title="History"
               rightElement={<HeaderActions variant="gradient" helpTopicId="history" />}
             />
 
-            {/* Don't show search bar during loading */}
+            {/* Witty loading line (relocated from the header greeting) */}
+            <Typography
+              variant="body"
+              color="secondary"
+              style={{ textAlign: 'center', paddingHorizontal: theme.spacing.lg, paddingTop: theme.spacing.lg }}
+            >
+              {greeting.timeBasedGreeting}
+            </Typography>
 
             {/* Skeleton loading */}
             <HistoryListSkeleton count={4} />
@@ -368,22 +322,25 @@ export const HistoryScreen: React.FC<HistoryScreenProps> = ({ navigation }) => {
               activeTab === 'debate' ? {
                 icon: 'sword-cross',
                 iconLibrary: 'material-community',
-                title: 'No debates yet',
+                title: greeting.timeBasedGreeting,
                 message: 'Start a debate to see it here',
                 actionText: 'Start Debating'
               } : activeTab === 'comparison' ? {
                 icon: 'git-compare-outline',
                 iconLibrary: 'ionicons',
-                title: 'No comparisons yet',
+                title: greeting.timeBasedGreeting,
                 message: 'Compare AI responses to see them here',
                 actionText: 'Start Comparing'
               } : activeTab === 'chat' ? {
                 icon: 'chatbubbles-outline',
                 iconLibrary: 'ionicons',
-                title: 'No chats yet',
+                title: greeting.timeBasedGreeting,
                 message: 'Start a conversation to see it here',
                 actionText: 'Start Chatting'
-              } : undefined
+              } : {
+                title: greeting.timeBasedGreeting,
+                message: greeting.welcomeMessage,
+              }
             }
           />
         }
@@ -439,21 +396,11 @@ export const HistoryScreen: React.FC<HistoryScreenProps> = ({ navigation }) => {
     <SafeAreaView edges={['left', 'right']} style={{ flex: 1, backgroundColor: theme.colors.background }}>
       <ErrorBoundary>
         <Box style={{ flex: 1, backgroundColor: theme.colors.background }}>
-          {/* Header with dynamic greeting */}
           <Header
             variant="gradient"
-            title={greeting.timeBasedGreeting}
-            subtitle={greeting.welcomeMessage}
-            showTime={true}
-            showDate={true}
-            animated={true}
+            slim
+            title="History"
             rightElement={<HeaderActions variant="gradient" helpTopicId="history" />}
-            showDemoBadge={isDemo}
-            actionButton={{
-              label: 'Manage',
-              onPress: handleHistoryActions,
-              variant: 'ghost'
-            }}
           />
 
           <DemoBanner

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -17,7 +17,6 @@ import { useDispatch } from 'react-redux';
 import { showSheet } from '@/store';
 
 // Custom hooks
-import { useGreeting } from '../hooks/useGreeting';
 import { usePremiumFeatures } from '../hooks/home/usePremiumFeatures';
 import { useAISelection } from '../hooks/home/useAISelection';
 import { useSessionManagement } from '../hooks/home/useSessionManagement';
@@ -37,7 +36,6 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   const { rs } = useResponsive();
 
   // Compose hooks for clean separation of concerns
-  const greeting = useGreeting();
   const premium = usePremiumFeatures();
   const aiSelection = useAISelection(premium.maxAIs);
   const session = useSessionManagement();
@@ -83,13 +81,9 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
       edges={['left', 'right']}>
       <Header
         variant="gradient"
-        title={greeting.timeBasedGreeting}
-        subtitle={greeting.welcomeMessage}
-        showTime={true}
-        showDate={true}
-        animated={true}
+        slim
+        title="Chat"
         rightElement={<HeaderActions variant="gradient" helpCategoryId="chat" />}
-        showDemoBadge={isDemo}
       />
 
       <TrialBanner />

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -82,7 +82,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
       <Header
         variant="gradient"
         slim
-        title="Chat"
+        title="Ask the Room"
         rightElement={<HeaderActions variant="gradient" helpCategoryId="chat" />}
       />
 
@@ -116,6 +116,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
               onStartChat={handleStartChat}
               onAddAI={handleAddAI}
               hideAddAI={isDemo}
+              hideHeaderTitle
               aiPersonalities={aiSelection.aiPersonalities}
               selectedModels={aiSelection.selectedModels}
               onPersonalityChange={aiSelection.changePersonality}

--- a/src/screens/PersonalitySystemScreen.tsx
+++ b/src/screens/PersonalitySystemScreen.tsx
@@ -171,8 +171,8 @@ export default function PersonalitySystemScreen() {
       {/* Header */}
       <Header
         variant="gradient"
-        title="Personality System"
-        subtitle="Customize AI Personalities"
+        title="AI Personalities"
+        subtitle="Customize voice and style"
         showBackButton={true}
         onBack={() => navigation.goBack()}
         animated={true}

--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -41,7 +41,7 @@ const StatsScreen: React.FC<StatsScreenProps> = ({ navigation }) => {
       {/* Header with back button */}
       <Header
         variant="gradient"
-        title="AI Performance Stats"
+        title="Performance Stats"
         showBackButton={true}
         onBack={() => navigation.goBack()}
       />


### PR DESCRIPTION
## Summary
- refresh compact app header copy across primary surfaces
- hide the redundant Home AI selector title while preserving configured-count and add-action row
- update focused screen and selector tests

## Verification
- ./node_modules/.bin/jest --runInBand --runTestsByPath __tests__/screens/HomeScreen.test.tsx __tests__/screens/HistoryScreen.test.tsx __tests__/screens/CompareSetupScreen.test.tsx __tests__/screens/DebateSetupScreen.test.tsx __tests__/screens/CreateSetupScreen.test.tsx
- npx tsc --noEmit
- focused ESLint on touched header files (existing no-explicit-any warnings only)