### PR TITLE
[codex] prevent history load flicker

### DIFF
--- a/__tests__/hooks/useSessionHistory.test.ts
+++ b/__tests__/hooks/useSessionHistory.test.ts
@@ -74,6 +74,39 @@ describe('useSessionHistory', () => {
     expect(mockGetAllSessions).toHaveBeenCalledTimes(2);
   });
 
+  it('refreshes in place after the initial load without re-entering initial loading', async () => {
+    const initialSessions: ChatSession[] = [{ ...baseSession, id: 'session-1' }];
+    const refreshedSessions: ChatSession[] = [{ ...baseSession, id: 'session-2' }];
+    let resolveRefresh!: (sessions: ChatSession[]) => void;
+
+    mockGetAllSessions.mockResolvedValueOnce(initialSessions);
+    mockGetAllSessions.mockImplementationOnce(() => new Promise(resolve => {
+      resolveRefresh = resolve;
+    }));
+
+    const { result } = renderHookWithProviders(() => useSessionHistory());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isRefreshing).toBe(false);
+
+    let refreshPromise!: Promise<void>;
+    act(() => {
+      refreshPromise = result.current.refresh();
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isRefreshing).toBe(true);
+
+    await act(async () => {
+      resolveRefresh(refreshedSessions);
+      await refreshPromise;
+    });
+
+    expect(result.current.sessions).toEqual(refreshedSessions);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isRefreshing).toBe(false);
+  });
+
   it('clears history and resets sessions to empty array', async () => {
     mockGetAllSessions.mockResolvedValueOnce([{ ...baseSession }]);
     mockClearAllSessions.mockResolvedValueOnce(undefined);

--- a/__tests__/screens/HistoryScreen.test.tsx
+++ b/__tests__/screens/HistoryScreen.test.tsx
@@ -51,12 +51,13 @@ const makeHistoryState = (overrides: Record<string, unknown> = {}) => {
   const {
     sessions = [createSession({})],
     isLoading = false,
+    isRefreshing = false,
     error = null,
     refresh = jest.fn(),
     ...rest
   } = overrides;
 
-  return { sessions, isLoading, error, refresh, ...rest };
+  return { sessions, isLoading, isRefreshing, error, refresh, ...rest };
 };
 
 const makeSearchState = (
@@ -123,10 +124,12 @@ jest.mock('@/hooks/history', () => ({
   useSessionPagination: (...args: unknown[]) => mockUseSessionPagination(...args),
 }));
 
+let focusEffectCallback: (() => void | (() => void)) | undefined;
 let focusEffectCleanup: (() => void) | undefined;
 
 jest.mock('@react-navigation/native', () => ({
   useFocusEffect: (cb: () => void | (() => void)) => {
+    focusEffectCallback = cb;
     const { useEffect } = require('react');
     useEffect(() => {
       const cleanup = cb();
@@ -312,6 +315,7 @@ describe('HistoryScreen', () => {
     alertSpy.mockReset();
     mockShowSuccess.mockClear();
     mockHandleWithToast.mockClear();
+    focusEffectCallback = undefined;
     focusEffectCleanup = undefined;
     mockHeaderProps = undefined;
     mockHistorySearchProps = undefined;
@@ -336,7 +340,7 @@ describe('HistoryScreen', () => {
     expect(typeof mockHistoryListProps.onSessionDelete).toBe('function');
     expect(mockHistoryListProps.selectionMode).toBe(false);
     expect(mockHistoryListProps.searchTerm).toBe(sessionSearchState.searchQuery);
-    expect(mockHistoryListProps.refreshing).toBe(sessionHistoryState.isLoading);
+    expect(mockHistoryListProps.refreshing).toBe(sessionHistoryState.isRefreshing);
     expect(mockHistoryListProps.onRefresh).toBe(sessionHistoryState.refresh);
 
     mockHistoryListProps.onSessionPress('session-1');
@@ -391,6 +395,11 @@ describe('HistoryScreen', () => {
   it('refreshes sessions after focus effect delay', () => {
     renderHistoryScreen();
     expect(sessionHistoryState.refresh).not.toHaveBeenCalled();
+
+    act(() => {
+      const cleanup = focusEffectCallback?.();
+      focusEffectCleanup = typeof cleanup === 'function' ? cleanup : undefined;
+    });
 
     act(() => {
       jest.advanceTimersByTime(300);

--- a/src/hooks/history/useSessionHistory.ts
+++ b/src/hooks/history/useSessionHistory.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { StorageService } from '../../services/chat';
 import { ChatSession } from '../../types';
 import { UseSessionHistoryReturn, SessionValidationResult } from '../../types/history';
@@ -6,16 +6,26 @@ import { UseSessionHistoryReturn, SessionValidationResult } from '../../types/hi
 export const useSessionHistory = (): UseSessionHistoryReturn => {
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [validationResult] = useState<SessionValidationResult | undefined>(undefined);
+  const hasLoadedOnceRef = useRef(false);
+  const loadRequestIdRef = useRef(0);
 
 
   /**
    * Load sessions from storage
    */
-  const loadSessions = useCallback(async () => {
+  const loadSessions = useCallback(async (showRefreshIndicator = false) => {
+    const requestId = ++loadRequestIdRef.current;
+    const isInitialLoad = !hasLoadedOnceRef.current;
+
     try {
-      setIsLoading(true);
+      if (isInitialLoad) {
+        setIsLoading(true);
+      } else if (showRefreshIndicator) {
+        setIsRefreshing(true);
+      }
       setError(null);
 
       // Simple direct load with timeout
@@ -39,17 +49,30 @@ export const useSessionHistory = (): UseSessionHistoryReturn => {
       // Free users get 3 chats + 3 comparisons + 3 debates = 9 total possible
       const limitedSessions = allSessions;
 
-      setSessions(limitedSessions);
+      if (requestId === loadRequestIdRef.current) {
+        setSessions(limitedSessions);
+        hasLoadedOnceRef.current = true;
+      }
 
     } catch (err) {
+      if (requestId !== loadRequestIdRef.current) {
+        return;
+      }
       const error = err instanceof Error ? err : new Error('Failed to load sessions');
       setError(error);
       console.error('Error loading chat history:', error);
       // Set empty array on error to prevent crashes
       setSessions([]);
+      hasLoadedOnceRef.current = true;
     } finally {
-      // Always set loading to false
-      setIsLoading(false);
+      if (requestId === loadRequestIdRef.current) {
+        if (isInitialLoad) {
+          setIsLoading(false);
+        }
+        if (!isInitialLoad && showRefreshIndicator) {
+          setIsRefreshing(false);
+        }
+      }
     }
   }, []);
 
@@ -57,7 +80,7 @@ export const useSessionHistory = (): UseSessionHistoryReturn => {
    * Refresh sessions (public API for manual refresh)
    */
   const refresh = useCallback(async () => {
-    await loadSessions();
+    await loadSessions(true);
   }, [loadSessions]);
 
   /**
@@ -84,6 +107,7 @@ export const useSessionHistory = (): UseSessionHistoryReturn => {
   return {
     sessions,
     isLoading,
+    isRefreshing,
     error,
     refresh,
     clearHistory,

--- a/src/screens/HistoryScreen.tsx
+++ b/src/screens/HistoryScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ScrollView, View, StyleSheet } from 'react-native';
 import { Box } from '../components/atoms';
@@ -44,12 +44,13 @@ export const HistoryScreen: React.FC<HistoryScreenProps> = ({ navigation }) => {
   const [selectedSession, setSelectedSession] = useState<ChatSession | null>(null);
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedSessionIds, setSelectedSessionIds] = useState<Set<string>>(new Set());
+  const hasFocusedOnceRef = useRef(false);
 
   // Show split view on iPad landscape with sufficient width
   const showSplitView = isTablet && isLandscape && width > 1024;
   
   // Compose hooks for different concerns
-  const { sessions, isLoading, error, refresh } = useSessionHistory();
+  const { sessions, isLoading, isRefreshing, error, refresh } = useSessionHistory();
   const { searchQuery, setSearchQuery, filteredSessions, clearSearch } = useSessionSearch(sessions);
   const { deleteSession, resumeSession, bulkDelete } = useSessionActions(navigation, refresh);
   useSessionStats(sessions); // For future analytics features
@@ -190,6 +191,11 @@ export const HistoryScreen: React.FC<HistoryScreenProps> = ({ navigation }) => {
   // Refresh sessions when screen comes into focus (tab navigation)
   useFocusEffect(
     React.useCallback(() => {
+      if (!hasFocusedOnceRef.current) {
+        hasFocusedOnceRef.current = true;
+        return undefined;
+      }
+
       // Increased delay to ensure storage operations complete
       const timer = setTimeout(() => {
         refresh();
@@ -304,7 +310,7 @@ export const HistoryScreen: React.FC<HistoryScreenProps> = ({ navigation }) => {
         selectedSessionIds={selectedSessionIds}
         selectionMode={selectionMode}
         searchTerm={searchQuery}
-        refreshing={isLoading}
+        refreshing={isRefreshing}
         onRefresh={refresh}
         testID="history-session-list"
         onLoadMore={shouldUsePagination ? loadMore : undefined}

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -181,6 +181,7 @@ export interface EmptyHistoryStateProps {
 export interface UseSessionHistoryReturn {
   sessions: ChatSession[];
   isLoading: boolean;
+  isRefreshing: boolean;
   error: Error | null;
   refresh: () => Promise<void>;
   clearHistory: () => Promise<void>;


### PR DESCRIPTION
## Summary
- Split History's initial loading state from later refresh state so refreshes do not remount the skeleton.
- Skip the redundant first focus refresh because the hook already loads on mount.
- Add regression coverage for in-place refresh behavior and updated screen wiring.

## Root Cause
History loaded on mount and then scheduled a focus refresh 300ms later. When the first load completed quickly, the focus refresh flipped the full-screen loading state back on and briefly replaced the loaded list with the skeleton.

## Validation
- `PATH=/Users/michaelspencer/.nvm/versions/node/v22.17.0/bin:$PATH npx jest --watch=false --runInBand __tests__/screens/HistoryScreen.test.tsx __tests__/hooks/useSessionHistory.test.ts`
- `PATH=/Users/michaelspencer/.nvm/versions/node/v22.17.0/bin:$PATH npm run check`
- `git diff --check`