### PR TITLE
Make usage recorders transactional and non-clobbering; persist sessionType

### DIFF
--- a/functions/src/usageTracking.ts
+++ b/functions/src/usageTracking.ts
@@ -17,6 +17,10 @@ interface ProviderBalance {
   errorMessage?: string;
 }
 
+type SessionType = 'chat' | 'debate' | 'comparison' | 'analyze';
+
+const SESSION_TYPES: SessionType[] = ['chat', 'debate', 'comparison', 'analyze'];
+
 interface UsageRecord {
   messageId: string;
   sessionId: string;
@@ -25,8 +29,13 @@ interface UsageRecord {
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
-  sessionType: 'chat' | 'debate' | 'comparison' | 'analyze';
+  sessionType: SessionType;
   timestamp: number;
+}
+
+interface ModeUsageStats {
+  tokens: number;
+  requests: number;
 }
 
 interface ImageGenerationRecord {
@@ -95,6 +104,7 @@ interface UsageSummary {
     media?: MediaGenerationStats;
   }>;
   byModel: Record<string, ModelUsageStats>;
+  byMode?: Record<string, ModeUsageStats>;
 }
 
 type FreeTierInteractionType = 'debate' | 'compare' | 'chat' | 'analyze';
@@ -289,49 +299,114 @@ async function fetchOpenAIBalance(apiKey: string): Promise<ProviderBalance> {
 // Record Usage (internal function)
 // ============================================================================
 
+interface UsageDocsMutation {
+  daily: Record<string, unknown>;
+  summary: Record<string, unknown>;
+}
+
 /**
- * Record usage for a message - called by proxyAIRequest after successful response
+ * Clamp a client-supplied session type to the known set. Unknown values fall
+ * back to 'chat' so byMode keys stay bounded.
  */
-export async function recordUsageInternal(
+export function normalizeSessionType(value: unknown): SessionType {
+  return SESSION_TYPES.includes(value as SessionType) ? (value as SessionType) : 'chat';
+}
+
+/**
+ * Monthly counters carried into a new summary write, reset together when the
+ * month rolls over. Every recorder must use this so a rollover triggered by
+ * one usage type also resets the others.
+ */
+export function monthlyCountersAfterRollover(
+  summaryData: UsageSummary | null,
+  monthStr: string
+): {
+  isNewMonth: boolean;
+  currentMonthTokens: number;
+  currentMonthRequests: number;
+  currentMonthImages: number;
+  currentMonthMedia: number;
+} {
+  const isNewMonth = !summaryData?.currentMonth || summaryData.currentMonth !== monthStr;
+  return {
+    isNewMonth,
+    currentMonthTokens: isNewMonth ? 0 : summaryData?.currentMonthTokens || 0,
+    currentMonthRequests: isNewMonth ? 0 : summaryData?.currentMonthRequests || 0,
+    currentMonthImages: isNewMonth ? 0 : summaryData?.currentMonthImages || 0,
+    currentMonthMedia: isNewMonth ? 0 : summaryData?.currentMonthMedia || 0,
+  };
+}
+
+/**
+ * Read both usage docs, apply a pure mutation, and write the results — all
+ * inside a transaction. The previous read-then-batch.set pattern lost updates
+ * when concurrent requests (multi-AI chat, debate, compare) interleaved.
+ *
+ * Mutators receive unflattened data (legacy docs were written with
+ * dot-notation keys) and must spread the current doc into their result so one
+ * usage type never erases another's fields.
+ */
+async function runUsageMutation(
   uid: string,
-  record: UsageRecord
+  dateStr: string,
+  mutate: (
+    dailyData: Record<string, unknown>,
+    summaryData: UsageSummary | null
+  ) => UsageDocsMutation
 ): Promise<void> {
-  console.log('recordUsageInternal called:', { uid, providerId: record.providerId, modelId: record.modelId, totalTokens: record.totalTokens });
-
   const db = getFirestore();
-  const now = new Date();
-  const dateStr = now.toISOString().split('T')[0]; // YYYY-MM-DD
-  const monthStr = dateStr.slice(0, 7); // YYYY-MM
-
-  console.log('Writing usage for date:', dateStr, 'month:', monthStr);
-
-  const batch = db.batch();
-
-  // 1. Update daily usage (provider-level)
   const dailyRef = db.collection('users').doc(uid)
     .collection('usage').doc('daily')
     .collection('days').doc(dateStr);
+  const summaryRef = db.collection('users').doc(uid).collection('usage').doc('summary');
 
-  // Get current daily doc to merge properly (unflatten to handle legacy flat-key data)
-  const dailyDoc = await dailyRef.get();
-  const dailyData = dailyDoc.exists ? unflattenObject(dailyDoc.data() || {}) : {};
+  await db.runTransaction(async (txn) => {
+    const [dailySnap, summarySnap] = await txn.getAll(dailyRef, summaryRef);
+    const dailyData = dailySnap.exists ? unflattenObject(dailySnap.data() || {}) : {};
+    const summaryData = summarySnap.exists
+      ? (unflattenObject(summarySnap.data() || {}) as unknown as UsageSummary)
+      : null;
 
-  // Build nested structure properly
-  const currentProviders = (dailyData.providers || {}) as Record<string, { totalInputTokens?: number; totalOutputTokens?: number; totalTokens?: number; requestCount?: number }>;
+    const { daily, summary } = mutate(dailyData, summaryData);
+    txn.set(dailyRef, daily);
+    txn.set(summaryRef, summary);
+  });
+}
+
+/**
+ * Pure mutation for a token usage record. Exported for tests.
+ */
+export function buildTokenUsageMutation(
+  dailyData: Record<string, unknown>,
+  summaryData: UsageSummary | null,
+  record: UsageRecord,
+  dateStr: string,
+  monthStr: string
+): UsageDocsMutation {
+  const sessionType = normalizeSessionType(record.sessionType);
+
+  // Daily doc
+  const currentProviders = (dailyData.providers || {}) as Record<string, Record<string, unknown>>;
   const currentProvider = currentProviders[record.providerId] || {};
 
   const currentByModel = (dailyData.byModel || {}) as Record<string, { inputTokens?: number; outputTokens?: number; requests?: number }>;
   const currentModel = currentByModel[record.modelId] || {};
 
-  batch.set(dailyRef, {
+  const currentByMode = (dailyData.byMode || {}) as Record<string, ModeUsageStats>;
+  const currentMode = currentByMode[sessionType] || { tokens: 0, requests: 0 };
+
+  const daily: Record<string, unknown> = {
+    ...dailyData,
     date: dateStr,
     providers: {
       ...currentProviders,
       [record.providerId]: {
-        totalInputTokens: (currentProvider.totalInputTokens || 0) + record.inputTokens,
-        totalOutputTokens: (currentProvider.totalOutputTokens || 0) + record.outputTokens,
-        totalTokens: (currentProvider.totalTokens || 0) + record.totalTokens,
-        requestCount: (currentProvider.requestCount || 0) + 1,
+        // Preserve images/media stats recorded for this provider today
+        ...currentProvider,
+        totalInputTokens: ((currentProvider.totalInputTokens as number) || 0) + record.inputTokens,
+        totalOutputTokens: ((currentProvider.totalOutputTokens as number) || 0) + record.outputTokens,
+        totalTokens: ((currentProvider.totalTokens as number) || 0) + record.totalTokens,
+        requestCount: ((currentProvider.requestCount as number) || 0) + 1,
       },
     },
     byModel: {
@@ -342,20 +417,21 @@ export async function recordUsageInternal(
         requests: (currentModel.requests || 0) + 1,
       },
     },
+    byMode: {
+      ...currentByMode,
+      [sessionType]: {
+        tokens: (currentMode.tokens || 0) + record.totalTokens,
+        requests: (currentMode.requests || 0) + 1,
+      },
+    },
     totalTokens: ((dailyData.totalTokens as number) || 0) + record.totalTokens,
     totalRequests: ((dailyData.totalRequests as number) || 0) + 1,
     updatedAt: FieldValue.serverTimestamp(),
-  });
+  };
 
-  // 2. Update summary
-  const summaryRef = db.collection('users').doc(uid).collection('usage').doc('summary');
+  // Summary doc
+  const counters = monthlyCountersAfterRollover(summaryData, monthStr);
 
-  // Get current summary to merge properly (unflatten to handle legacy flat-key data)
-  const summaryDoc = await summaryRef.get();
-  const summaryData = summaryDoc.exists ? unflattenObject(summaryDoc.data() || {}) as unknown as UsageSummary : null;
-  const isNewMonth = !summaryData?.currentMonth || summaryData.currentMonth !== monthStr;
-
-  // Build nested structures properly
   const summaryByProvider = summaryData?.byProvider || {};
   const summaryProviderStats = summaryByProvider[record.providerId] || {
     tokens: 0,
@@ -373,14 +449,20 @@ export async function recordUsageInternal(
     lastUsed: 0,
   };
 
-  const updatedSummary = {
+  const summaryByMode = summaryData?.byMode || {};
+  const summaryModeStats = summaryByMode[sessionType] || { tokens: 0, requests: 0 };
+
+  const summary: Record<string, unknown> = {
+    ...(summaryData ?? {}),
     updatedAt: Date.now(),
     totalTokensAllTime: (summaryData?.totalTokensAllTime || 0) + record.totalTokens,
     totalRequestsAllTime: (summaryData?.totalRequestsAllTime || 0) + 1,
     totalImagesAllTime: summaryData?.totalImagesAllTime || 0,
-    currentMonthTokens: isNewMonth ? record.totalTokens : (summaryData?.currentMonthTokens || 0) + record.totalTokens,
-    currentMonthRequests: isNewMonth ? 1 : (summaryData?.currentMonthRequests || 0) + 1,
-    currentMonthImages: isNewMonth ? 0 : (summaryData?.currentMonthImages || 0),
+    totalMediaAllTime: summaryData?.totalMediaAllTime || 0,
+    currentMonthTokens: counters.currentMonthTokens + record.totalTokens,
+    currentMonthRequests: counters.currentMonthRequests + 1,
+    currentMonthImages: counters.currentMonthImages,
+    currentMonthMedia: counters.currentMonthMedia,
     currentMonth: monthStr,
     byProvider: {
       ...summaryByProvider,
@@ -402,12 +484,36 @@ export async function recordUsageInternal(
         lastUsed: Date.now(),
       },
     },
+    byMode: {
+      ...summaryByMode,
+      [sessionType]: {
+        tokens: (summaryModeStats.tokens || 0) + record.totalTokens,
+        requests: (summaryModeStats.requests || 0) + 1,
+      },
+    },
   };
 
-  batch.set(summaryRef, updatedSummary);
+  return { daily, summary };
+}
 
-  await batch.commit();
-  console.log('Usage batch committed successfully for:', { uid, dateStr, providerId: record.providerId });
+/**
+ * Record usage for a message - called by proxyAIRequest after successful response
+ */
+export async function recordUsageInternal(
+  uid: string,
+  record: UsageRecord
+): Promise<void> {
+  console.log('recordUsageInternal called:', { uid, providerId: record.providerId, modelId: record.modelId, totalTokens: record.totalTokens, sessionType: record.sessionType });
+
+  const now = new Date();
+  const dateStr = now.toISOString().split('T')[0]; // YYYY-MM-DD
+  const monthStr = dateStr.slice(0, 7); // YYYY-MM
+
+  await runUsageMutation(uid, dateStr, (dailyData, summaryData) =>
+    buildTokenUsageMutation(dailyData, summaryData, record, dateStr, monthStr)
+  );
+
+  console.log('Usage transaction committed for:', { uid, dateStr, providerId: record.providerId });
 }
 
 function normalizeFreeTierUsage(data: FirebaseFirestore.DocumentData | undefined): FreeTierUsageState {
@@ -516,29 +622,16 @@ export const recordFreeTierInteraction = onCall(
 // ============================================================================
 
 /**
- * Record image generation usage - called after successful image generation
+ * Pure mutation for an image generation record. Exported for tests.
  */
-export async function recordImageGenerationInternal(
-  uid: string,
-  record: ImageGenerationRecord
-): Promise<void> {
-  const db = getFirestore();
-  const now = new Date();
-  const dateStr = now.toISOString().split('T')[0]; // YYYY-MM-DD
-  const monthStr = dateStr.slice(0, 7); // YYYY-MM
-
-  const batch = db.batch();
-
-  // 1. Update daily usage
-  const dailyRef = db.collection('users').doc(uid)
-    .collection('usage').doc('daily')
-    .collection('days').doc(dateStr);
-
-  // Get current daily doc to merge properly (unflatten to handle legacy flat-key data)
-  const dailyDoc = await dailyRef.get();
-  const dailyData = dailyDoc.exists ? unflattenObject(dailyDoc.data() || {}) : {};
-
-  // Build nested structure properly
+export function buildImageGenerationMutation(
+  dailyData: Record<string, unknown>,
+  summaryData: UsageSummary | null,
+  record: ImageGenerationRecord,
+  dateStr: string,
+  monthStr: string
+): UsageDocsMutation {
+  // Daily doc
   const currentProviders = (dailyData.providers || {}) as Record<string, Record<string, unknown>>;
   const currentProvider = currentProviders[record.providerId] || {};
   const currentImages = (currentProvider.images as ImageGenerationStats) || {
@@ -561,7 +654,9 @@ export async function recordImageGenerationInternal(
     },
   };
 
-  batch.set(dailyRef, {
+  const daily: Record<string, unknown> = {
+    // Preserve token fields (byModel, byMode, totalTokens, totalRequests, …)
+    ...dailyData,
     date: dateStr,
     totalImages: ((dailyData.totalImages as number) || 0) + record.imageCount,
     providers: {
@@ -572,17 +667,11 @@ export async function recordImageGenerationInternal(
       },
     },
     updatedAt: FieldValue.serverTimestamp(),
-  });
+  };
 
-  // 2. Update summary
-  const summaryRef = db.collection('users').doc(uid).collection('usage').doc('summary');
+  // Summary doc
+  const counters = monthlyCountersAfterRollover(summaryData, monthStr);
 
-  // Get current summary to merge properly (unflatten to handle legacy flat-key data)
-  const summaryDoc = await summaryRef.get();
-  const summaryData = summaryDoc.exists ? unflattenObject(summaryDoc.data() || {}) as unknown as UsageSummary : null;
-  const isNewMonth = !summaryData?.currentMonth || summaryData.currentMonth !== monthStr;
-
-  // Build nested structure properly
   const currentByProvider = summaryData?.byProvider || {};
   const currentProviderStats = currentByProvider[record.providerId] || {
     tokens: 0,
@@ -609,14 +698,17 @@ export async function recordImageGenerationInternal(
     },
   };
 
-  const updatedSummary = {
+  const summary: Record<string, unknown> = {
+    ...(summaryData ?? {}),
     updatedAt: Date.now(),
     totalTokensAllTime: summaryData?.totalTokensAllTime || 0,
     totalRequestsAllTime: summaryData?.totalRequestsAllTime || 0,
     totalImagesAllTime: (summaryData?.totalImagesAllTime || 0) + record.imageCount,
-    currentMonthTokens: isNewMonth ? 0 : (summaryData?.currentMonthTokens || 0),
-    currentMonthRequests: isNewMonth ? 0 : (summaryData?.currentMonthRequests || 0),
-    currentMonthImages: isNewMonth ? record.imageCount : (summaryData?.currentMonthImages || 0) + record.imageCount,
+    totalMediaAllTime: summaryData?.totalMediaAllTime || 0,
+    currentMonthTokens: counters.currentMonthTokens,
+    currentMonthRequests: counters.currentMonthRequests,
+    currentMonthImages: counters.currentMonthImages + record.imageCount,
+    currentMonthMedia: counters.currentMonthMedia,
     currentMonth: monthStr,
     byProvider: {
       ...currentByProvider,
@@ -629,9 +721,23 @@ export async function recordImageGenerationInternal(
     byModel: summaryData?.byModel || {},
   };
 
-  batch.set(summaryRef, updatedSummary);
+  return { daily, summary };
+}
 
-  await batch.commit();
+/**
+ * Record image generation usage - called after successful image generation
+ */
+export async function recordImageGenerationInternal(
+  uid: string,
+  record: ImageGenerationRecord
+): Promise<void> {
+  const now = new Date();
+  const dateStr = now.toISOString().split('T')[0]; // YYYY-MM-DD
+  const monthStr = dateStr.slice(0, 7); // YYYY-MM
+
+  await runUsageMutation(uid, dateStr, (dailyData, summaryData) =>
+    buildImageGenerationMutation(dailyData, summaryData, record, dateStr, monthStr)
+  );
 }
 
 /**
@@ -674,24 +780,17 @@ export const recordImageGeneration = onCall(
  * Record media generation usage by provider/media type only.
  * Cost estimates are intentionally excluded because usage is BYOK.
  */
-export async function recordMediaGenerationInternal(
-  uid: string,
-  record: MediaGenerationRecord
-): Promise<void> {
-  const db = getFirestore();
-  const now = new Date();
-  const dateStr = now.toISOString().split('T')[0];
-  const monthStr = dateStr.slice(0, 7);
-
-  const batch = db.batch();
-
-  const dailyRef = db.collection('users').doc(uid)
-    .collection('usage').doc('daily')
-    .collection('days').doc(dateStr);
-
-  const dailyDoc = await dailyRef.get();
-  const dailyData = dailyDoc.exists ? unflattenObject(dailyDoc.data() || {}) : {};
-
+/**
+ * Pure mutation for a media generation record. Exported for tests.
+ */
+export function buildMediaGenerationMutation(
+  dailyData: Record<string, unknown>,
+  summaryData: UsageSummary | null,
+  record: MediaGenerationRecord,
+  dateStr: string,
+  monthStr: string
+): UsageDocsMutation {
+  // Daily doc
   const currentProviders = (dailyData.providers || {}) as Record<string, Record<string, unknown>>;
   const currentProvider = currentProviders[record.providerId] || {};
   const currentMedia = (currentProvider.media as MediaGenerationStats) || {
@@ -712,7 +811,9 @@ export async function recordMediaGenerationInternal(
     },
   };
 
-  batch.set(dailyRef, {
+  const daily: Record<string, unknown> = {
+    // Preserve token fields (byModel, byMode, totalTokens, totalRequests, …)
+    ...dailyData,
     date: dateStr,
     totalMedia: ((dailyData.totalMedia as number) || 0) + 1,
     providers: {
@@ -723,12 +824,10 @@ export async function recordMediaGenerationInternal(
       },
     },
     updatedAt: FieldValue.serverTimestamp(),
-  });
+  };
 
-  const summaryRef = db.collection('users').doc(uid).collection('usage').doc('summary');
-  const summaryDoc = await summaryRef.get();
-  const summaryData = summaryDoc.exists ? unflattenObject(summaryDoc.data() || {}) as unknown as UsageSummary : null;
-  const isNewMonth = !summaryData?.currentMonth || summaryData.currentMonth !== monthStr;
+  // Summary doc
+  const counters = monthlyCountersAfterRollover(summaryData, monthStr);
 
   const currentByProvider = summaryData?.byProvider || {};
   const currentProviderStats = currentByProvider[record.providerId] || {
@@ -754,16 +853,17 @@ export async function recordMediaGenerationInternal(
     },
   };
 
-  batch.set(summaryRef, {
+  const summary: Record<string, unknown> = {
+    ...(summaryData ?? {}),
     updatedAt: Date.now(),
     totalTokensAllTime: summaryData?.totalTokensAllTime || 0,
     totalRequestsAllTime: summaryData?.totalRequestsAllTime || 0,
     totalImagesAllTime: summaryData?.totalImagesAllTime || 0,
     totalMediaAllTime: (summaryData?.totalMediaAllTime || 0) + 1,
-    currentMonthTokens: isNewMonth ? 0 : (summaryData?.currentMonthTokens || 0),
-    currentMonthRequests: isNewMonth ? 0 : (summaryData?.currentMonthRequests || 0),
-    currentMonthImages: isNewMonth ? 0 : (summaryData?.currentMonthImages || 0),
-    currentMonthMedia: isNewMonth ? 1 : (summaryData?.currentMonthMedia || 0) + 1,
+    currentMonthTokens: counters.currentMonthTokens,
+    currentMonthRequests: counters.currentMonthRequests,
+    currentMonthImages: counters.currentMonthImages,
+    currentMonthMedia: counters.currentMonthMedia + 1,
     currentMonth: monthStr,
     byProvider: {
       ...currentByProvider,
@@ -774,9 +874,22 @@ export async function recordMediaGenerationInternal(
       },
     },
     byModel: summaryData?.byModel || {},
-  });
+  };
 
-  await batch.commit();
+  return { daily, summary };
+}
+
+export async function recordMediaGenerationInternal(
+  uid: string,
+  record: MediaGenerationRecord
+): Promise<void> {
+  const now = new Date();
+  const dateStr = now.toISOString().split('T')[0];
+  const monthStr = dateStr.slice(0, 7);
+
+  await runUsageMutation(uid, dateStr, (dailyData, summaryData) =>
+    buildMediaGenerationMutation(dailyData, summaryData, record, dateStr, monthStr)
+  );
 }
 
 export const recordMediaGeneration = onCall(

--- a/functions/test/usageTracking.test.js
+++ b/functions/test/usageTracking.test.js
@@ -1,0 +1,277 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  buildTokenUsageMutation,
+  buildImageGenerationMutation,
+  buildMediaGenerationMutation,
+  monthlyCountersAfterRollover,
+  normalizeSessionType,
+} = require('../lib/usageTracking');
+
+const DATE = '2026-06-12';
+const MONTH = '2026-06';
+
+function tokenRecord(overrides = {}) {
+  return {
+    messageId: 'm1',
+    sessionId: 's1',
+    providerId: 'claude',
+    modelId: 'claude-sonnet-4-6',
+    inputTokens: 600,
+    outputTokens: 400,
+    totalTokens: 1000,
+    sessionType: 'chat',
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+test('normalizeSessionType accepts known modes and falls back to chat', () => {
+  assert.equal(normalizeSessionType('debate'), 'debate');
+  assert.equal(normalizeSessionType('analyze'), 'analyze');
+  assert.equal(normalizeSessionType('comparison'), 'comparison');
+  assert.equal(normalizeSessionType('not-a-mode'), 'chat');
+  assert.equal(normalizeSessionType(undefined), 'chat');
+});
+
+test('monthlyCountersAfterRollover carries counters within the same month', () => {
+  const counters = monthlyCountersAfterRollover(
+    { currentMonth: MONTH, currentMonthTokens: 10, currentMonthRequests: 2, currentMonthImages: 3, currentMonthMedia: 4 },
+    MONTH
+  );
+  assert.equal(counters.isNewMonth, false);
+  assert.deepEqual(
+    [counters.currentMonthTokens, counters.currentMonthRequests, counters.currentMonthImages, counters.currentMonthMedia],
+    [10, 2, 3, 4]
+  );
+});
+
+test('monthlyCountersAfterRollover resets every counter on a new month', () => {
+  const counters = monthlyCountersAfterRollover(
+    { currentMonth: '2026-05', currentMonthTokens: 10, currentMonthRequests: 2, currentMonthImages: 3, currentMonthMedia: 4 },
+    MONTH
+  );
+  assert.equal(counters.isNewMonth, true);
+  assert.deepEqual(
+    [counters.currentMonthTokens, counters.currentMonthRequests, counters.currentMonthImages, counters.currentMonthMedia],
+    [0, 0, 0, 0]
+  );
+});
+
+test('token usage increments daily provider, model, mode, and totals', () => {
+  const { daily } = buildTokenUsageMutation(
+    {
+      date: DATE,
+      providers: { claude: { totalInputTokens: 100, totalOutputTokens: 50, totalTokens: 150, requestCount: 1 } },
+      byModel: { 'claude-sonnet-4-6': { inputTokens: 100, outputTokens: 50, requests: 1 } },
+      byMode: { chat: { tokens: 150, requests: 1 } },
+      totalTokens: 150,
+      totalRequests: 1,
+    },
+    null,
+    tokenRecord(),
+    DATE,
+    MONTH
+  );
+
+  assert.deepEqual(daily.providers.claude, {
+    totalInputTokens: 700,
+    totalOutputTokens: 450,
+    totalTokens: 1150,
+    requestCount: 2,
+  });
+  assert.deepEqual(daily.byModel['claude-sonnet-4-6'], { inputTokens: 700, outputTokens: 450, requests: 2 });
+  assert.deepEqual(daily.byMode.chat, { tokens: 1150, requests: 2 });
+  assert.equal(daily.totalTokens, 1150);
+  assert.equal(daily.totalRequests, 2);
+});
+
+test('token usage records byMode per session type in daily and summary docs', () => {
+  const { daily, summary } = buildTokenUsageMutation(
+    {},
+    null,
+    tokenRecord({ sessionType: 'debate' }),
+    DATE,
+    MONTH
+  );
+
+  assert.deepEqual(daily.byMode, { debate: { tokens: 1000, requests: 1 } });
+  assert.deepEqual(summary.byMode, { debate: { tokens: 1000, requests: 1 } });
+});
+
+test('token usage clamps unknown session types to chat', () => {
+  const { summary } = buildTokenUsageMutation({}, null, tokenRecord({ sessionType: 'weird' }), DATE, MONTH);
+  assert.deepEqual(Object.keys(summary.byMode), ['chat']);
+});
+
+test('token usage preserves image stats on the same daily provider', () => {
+  // Regression: the old write replaced the provider object, erasing images
+  const images = { totalImages: 2, byDimensions: { '1024x1024': 2 }, byQuality: { hd: 2 } };
+  const { daily } = buildTokenUsageMutation(
+    { providers: { claude: { images, totalTokens: 0 } } },
+    null,
+    tokenRecord(),
+    DATE,
+    MONTH
+  );
+
+  assert.deepEqual(daily.providers.claude.images, images);
+  assert.equal(daily.providers.claude.totalTokens, 1000);
+});
+
+test('token usage preserves media counters and unknown fields in the summary', () => {
+  // Regression: the old write rebuilt the summary without media fields
+  const { summary } = buildTokenUsageMutation(
+    {},
+    {
+      currentMonth: MONTH,
+      currentMonthTokens: 5,
+      currentMonthRequests: 1,
+      currentMonthImages: 7,
+      currentMonthMedia: 3,
+      totalTokensAllTime: 5,
+      totalRequestsAllTime: 1,
+      totalImagesAllTime: 7,
+      totalMediaAllTime: 3,
+      byProvider: {},
+      byModel: {},
+      someFutureField: 'kept',
+    },
+    tokenRecord(),
+    DATE,
+    MONTH
+  );
+
+  assert.equal(summary.totalMediaAllTime, 3);
+  assert.equal(summary.currentMonthMedia, 3);
+  assert.equal(summary.currentMonthImages, 7);
+  assert.equal(summary.someFutureField, 'kept');
+  assert.equal(summary.currentMonthTokens, 1005);
+  assert.equal(summary.currentMonthRequests, 2);
+});
+
+test('token usage month rollover resets all counters before applying the record', () => {
+  const { summary } = buildTokenUsageMutation(
+    {},
+    {
+      currentMonth: '2026-05',
+      currentMonthTokens: 999,
+      currentMonthRequests: 99,
+      currentMonthImages: 9,
+      currentMonthMedia: 9,
+      totalTokensAllTime: 999,
+      totalRequestsAllTime: 99,
+      totalImagesAllTime: 9,
+      byProvider: {},
+      byModel: {},
+    },
+    tokenRecord(),
+    DATE,
+    MONTH
+  );
+
+  assert.equal(summary.currentMonth, MONTH);
+  assert.equal(summary.currentMonthTokens, 1000);
+  assert.equal(summary.currentMonthRequests, 1);
+  assert.equal(summary.currentMonthImages, 0);
+  assert.equal(summary.currentMonthMedia, 0);
+  assert.equal(summary.totalTokensAllTime, 1999);
+});
+
+test('image generation preserves token fields in the daily doc', () => {
+  // Regression: the old write replaced the daily doc, erasing the day's
+  // byModel, byMode, totalTokens, and totalRequests
+  const { daily } = buildImageGenerationMutation(
+    {
+      date: DATE,
+      providers: { openai: { totalTokens: 500, requestCount: 2 } },
+      byModel: { 'gpt-5.5': { inputTokens: 300, outputTokens: 200, requests: 2 } },
+      byMode: { chat: { tokens: 500, requests: 2 } },
+      totalTokens: 500,
+      totalRequests: 2,
+    },
+    null,
+    { providerId: 'openai', modelId: 'dall-e-3', imageCount: 1, dimensions: '1024x1024', quality: 'hd', timestamp: Date.now() },
+    DATE,
+    MONTH
+  );
+
+  assert.equal(daily.totalTokens, 500);
+  assert.equal(daily.totalRequests, 2);
+  assert.deepEqual(daily.byModel['gpt-5.5'], { inputTokens: 300, outputTokens: 200, requests: 2 });
+  assert.deepEqual(daily.byMode.chat, { tokens: 500, requests: 2 });
+  assert.equal(daily.totalImages, 1);
+  assert.equal(daily.providers.openai.totalTokens, 500);
+  assert.deepEqual(daily.providers.openai.images, {
+    totalImages: 1,
+    byDimensions: { '1024x1024': 1 },
+    byQuality: { hd: 1 },
+  });
+});
+
+test('image generation preserves media counters in the summary', () => {
+  const { summary } = buildImageGenerationMutation(
+    {},
+    {
+      currentMonth: MONTH,
+      currentMonthTokens: 5,
+      currentMonthRequests: 1,
+      currentMonthImages: 2,
+      currentMonthMedia: 3,
+      totalTokensAllTime: 5,
+      totalRequestsAllTime: 1,
+      totalImagesAllTime: 2,
+      totalMediaAllTime: 3,
+      byProvider: {},
+      byModel: {},
+    },
+    { providerId: 'openai', modelId: 'dall-e-3', imageCount: 2, dimensions: '512x512', timestamp: Date.now() },
+    DATE,
+    MONTH
+  );
+
+  assert.equal(summary.totalImagesAllTime, 4);
+  assert.equal(summary.currentMonthImages, 4);
+  assert.equal(summary.totalMediaAllTime, 3);
+  assert.equal(summary.currentMonthMedia, 3);
+  assert.equal(summary.currentMonthTokens, 5);
+});
+
+test('media generation preserves token and image fields', () => {
+  const { daily, summary } = buildMediaGenerationMutation(
+    {
+      totalTokens: 100,
+      totalImages: 5,
+      byModel: { 'claude-sonnet-4-6': { inputTokens: 60, outputTokens: 40, requests: 1 } },
+    },
+    {
+      currentMonth: MONTH,
+      currentMonthTokens: 100,
+      currentMonthRequests: 1,
+      currentMonthImages: 5,
+      currentMonthMedia: 0,
+      totalTokensAllTime: 100,
+      totalRequestsAllTime: 1,
+      totalImagesAllTime: 5,
+      byProvider: {},
+      byModel: {},
+    },
+    { providerId: 'elevenlabs', modelId: 'eleven-v3', mediaType: 'audio', operation: 'tts', timestamp: Date.now() },
+    DATE,
+    MONTH
+  );
+
+  assert.equal(daily.totalTokens, 100);
+  assert.equal(daily.totalImages, 5);
+  assert.equal(daily.totalMedia, 1);
+  assert.deepEqual(daily.providers.elevenlabs.media, {
+    totalGenerations: 1,
+    byMediaType: { audio: 1 },
+    byOperation: { tts: 1 },
+  });
+  assert.equal(summary.currentMonthTokens, 100);
+  assert.equal(summary.currentMonthImages, 5);
+  assert.equal(summary.currentMonthMedia, 1);
+  assert.equal(summary.totalMediaAllTime, 1);
+});


### PR DESCRIPTION
## Summary

Companion to symposiumai-web PR #172 (Usage dashboard overhaul, v2.0.2). That investigation found two data-integrity bugs in `functions/src/usageTracking.ts`; closer reading revealed a third, worse one. All three usage recorders (`recordUsageInternal`, `recordImageGenerationInternal`, `recordMediaGenerationInternal`) shared a read-then-`batch.set` pattern:

1. **Lost updates (race)** — a 3-AI chat, debate, or compare fires parallel proxy calls; two recorders could read the same state and the second whole-document `set` silently dropped the first's increments.
2. **Field clobbering (no concurrency needed)** — each recorder rebuilt the *entire* daily and summary docs from only the fields it knew about. Recording an image **erased that day's `byModel`/`totalTokens`/`totalRequests`**; recording token usage erased the media counters; media recording erased image dimensions on the daily doc's sibling fields.
3. **`sessionType` discarded** — all three proxies send it (`chat`/`debate`/`comparison`/`analyze`) but it was never persisted, blocking per-mode usage breakdowns.

## Changes

- Recorders now run inside `db.runTransaction` (retried on contention), reading both docs via `txn.getAll` before writing.
- Mutation logic extracted into **pure builder functions** (`buildTokenUsageMutation`, `buildImageGenerationMutation`, `buildMediaGenerationMutation`) that spread the current document before applying increments, so unrelated fields always survive. Legacy flat-key unflattening behavior is preserved.
- Month rollover centralized in `monthlyCountersAfterRollover` — a rollover triggered by any usage type now resets all four monthly counters (`tokens`/`requests`/`images`/`media`) together; previously the token recorder didn't know about media counters at all.
- **`byMode` persisted** on daily docs and the summary: `{ [sessionType]: { tokens, requests } }`, with unknown values clamped to `chat` so keys stay bounded. This unblocks a future per-mode breakdown on the web Usage dashboard once data accrues.

No callable signatures changed; `getUsageStats` returns the new `byMode` fields automatically. Existing docs need no migration — fields accrete from zero.

## Test plan
- [x] New `functions/test/usageTracking.test.js`: 12 tests covering increments, byMode persistence, sessionType clamping, month rollover, and regressions for both clobbering directions
- [x] `npm test` (build + node --test): 43/44 pass — the one failure is `mediaProxy.test.js` ElevenLabs voice mapping, which also fails on master without these changes (pre-existing, unrelated)
- [x] `tsc --noEmit` clean
- [ ] After deploy: generate an image and send a chat message in the same day, confirm the daily doc keeps both token and image fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)