### PR TITLE
Functions: testApiKey + 2FA backup-code callables (Settings v2.0.6)

### DIFF
--- a/functions/src/backupCodes.ts
+++ b/functions/src/backupCodes.ts
@@ -1,0 +1,153 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { getFirestore, FieldValue, Timestamp } from 'firebase-admin/firestore';
+import * as crypto from 'crypto';
+
+/**
+ * Two-factor backup (recovery) codes.
+ *
+ * Firebase MFA (TOTP/SMS) has no native backup codes, so this is custom:
+ * generate N single-use codes, store per-code salted scrypt hashes, and return
+ * the plaintext once. Stored at users/{uid}/security/backupCodes — a
+ * subcollection that deleteAccount already wipes, so no extra cleanup is needed.
+ *
+ * Verification at sign-in (verifyAndConsumeBackupCode) is provided for a future
+ * MFA-resolver integration; it is not yet wired to a sign-in flow.
+ */
+
+const CODE_COUNT = 10;
+const CODE_LENGTH = 8;
+// Crockford-ish alphabet: no ambiguous I/L/O/0/1.
+const ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+const SALT_BYTES = 16;
+const HASH_BYTES = 32;
+
+interface StoredCode {
+  salt: string; // hex
+  hash: string; // hex (scrypt of normalized code)
+  usedAt: Timestamp | null;
+}
+
+function backupCodesRef(uid: string) {
+  return getFirestore().collection('users').doc(uid).collection('security').doc('backupCodes');
+}
+
+/** Strip formatting so "abcd-efgh" and "ABCDEFGH" hash identically. */
+function normalizeCode(input: string): string {
+  return input.toUpperCase().replace(/[^A-Z0-9]/g, '');
+}
+
+function generatePlainCode(): string {
+  let code = '';
+  for (let i = 0; i < CODE_LENGTH; i++) {
+    code += ALPHABET[crypto.randomInt(ALPHABET.length)];
+  }
+  return code;
+}
+
+/** Display format, e.g. "ABCD-EFGH". */
+function formatForDisplay(code: string): string {
+  return `${code.slice(0, 4)}-${code.slice(4)}`;
+}
+
+function hashCode(normalized: string, salt: Buffer): Buffer {
+  return crypto.scryptSync(normalized, salt, HASH_BYTES);
+}
+
+export const generateBackupCodes = onCall(async (request): Promise<{ codes: string[] }> => {
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'Must be authenticated to generate backup codes');
+  }
+
+  const uid = request.auth.uid;
+  const plainCodes: string[] = [];
+  const stored: StoredCode[] = [];
+
+  for (let i = 0; i < CODE_COUNT; i++) {
+    const raw = generatePlainCode();
+    const salt = crypto.randomBytes(SALT_BYTES);
+    stored.push({
+      salt: salt.toString('hex'),
+      hash: hashCode(raw, salt).toString('hex'),
+      usedAt: null,
+    });
+    plainCodes.push(formatForDisplay(raw));
+  }
+
+  try {
+    // Overwrites any previous set — regenerating invalidates old codes.
+    await backupCodesRef(uid).set({
+      codes: stored,
+      remaining: CODE_COUNT,
+      generatedAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  } catch (error) {
+    console.error('Error generating backup codes:', error);
+    throw new HttpsError('internal', 'Failed to generate backup codes');
+  }
+
+  return { codes: plainCodes };
+});
+
+export const getBackupCodesStatus = onCall(
+  async (request): Promise<{ remaining: number; generatedAt: string | null }> => {
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Must be authenticated');
+    }
+
+    try {
+      const doc = await backupCodesRef(request.auth.uid).get();
+      if (!doc.exists) {
+        return { remaining: 0, generatedAt: null };
+      }
+      const data = doc.data() as { codes?: StoredCode[]; generatedAt?: Timestamp } | undefined;
+      const remaining = (data?.codes ?? []).filter((c) => !c.usedAt).length;
+      const generatedAt = data?.generatedAt?.toDate?.()?.toISOString() ?? null;
+      return { remaining, generatedAt };
+    } catch (error) {
+      console.error('Error reading backup codes status:', error);
+      throw new HttpsError('internal', 'Failed to read backup codes status');
+    }
+  }
+);
+
+/**
+ * Verify a backup code and consume it (single-use). Returns true on success.
+ *
+ * Provided for a future sign-in MFA-resolver integration — not yet wired to an
+ * endpoint. Runs in a transaction so a code can't be consumed twice.
+ */
+export async function verifyAndConsumeBackupCode(uid: string, input: string): Promise<boolean> {
+  const normalized = normalizeCode(input);
+  if (!normalized) return false;
+
+  const db = getFirestore();
+  const ref = backupCodesRef(uid);
+
+  return db.runTransaction(async (tx) => {
+    const doc = await tx.get(ref);
+    if (!doc.exists) return false;
+
+    const data = doc.data() as { codes?: StoredCode[] } | undefined;
+    const codes = data?.codes ?? [];
+
+    let matchedIndex = -1;
+    for (let i = 0; i < codes.length; i++) {
+      const entry = codes[i];
+      if (entry.usedAt) continue;
+      const candidate = hashCode(normalized, Buffer.from(entry.salt, 'hex'));
+      const stored = Buffer.from(entry.hash, 'hex');
+      if (candidate.length === stored.length && crypto.timingSafeEqual(candidate, stored)) {
+        matchedIndex = i;
+        break;
+      }
+    }
+
+    if (matchedIndex === -1) return false;
+
+    codes[matchedIndex] = { ...codes[matchedIndex], usedAt: Timestamp.now() };
+    const remaining = codes.filter((c) => !c.usedAt).length;
+    tx.update(ref, { codes, remaining, updatedAt: FieldValue.serverTimestamp() });
+    return true;
+  });
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -16,6 +16,7 @@ export { testApiKey } from './testApiKey';
 
 // Two-Factor Backup Codes
 export { generateBackupCodes, getBackupCodesStatus } from './backupCodes';
+export { redeemBackupCode } from './redeemBackupCode';
 
 // Data Connector Key Management
 export { saveDataServiceKey, deleteDataServiceKey, getConfiguredDataServices } from './dataConnectors';

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -12,6 +12,10 @@ export {
 
 // API Key Management
 export { saveApiKey, deleteApiKey, getConfiguredProviders } from './apiKeys';
+export { testApiKey } from './testApiKey';
+
+// Two-Factor Backup Codes
+export { generateBackupCodes, getBackupCodesStatus } from './backupCodes';
 
 // Data Connector Key Management
 export { saveDataServiceKey, deleteDataServiceKey, getConfiguredDataServices } from './dataConnectors';

--- a/functions/src/redeemBackupCode.ts
+++ b/functions/src/redeemBackupCode.ts
@@ -1,0 +1,142 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { defineSecret } from 'firebase-functions/params';
+import * as admin from 'firebase-admin';
+import axios from 'axios';
+import { OAuth2Client } from 'google-auth-library';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { verifyAndConsumeBackupCode } from './backupCodes';
+
+try { admin.app(); } catch { admin.initializeApp(); }
+
+// Reuses the same Web API key used by authRateLimiting for password verification.
+const symposiumWebApiKey = defineSecret('SYMPOSIUM_WEB_API_KEY');
+// Google OAuth 2.0 Web client ID (the audience of Google sign-in id_tokens).
+const googleOAuthClientId = defineSecret('GOOGLE_OAUTH_CLIENT_ID');
+// Apple Services ID (audience of Apple id_tokens), e.g. com.braveheartinnovations.debateai.signin
+const appleServiceId = defineSecret('APPLE_SERVICE_ID');
+
+const APPLE_JWKS = createRemoteJWKSet(new URL('https://appleid.apple.com/auth/keys'));
+
+/**
+ * Confirm the password is correct without completing sign-in. A 200 from
+ * accounts:signInWithPassword means valid (whether or not it returns an idToken
+ * vs an mfaPendingCredential); any error means the password is wrong.
+ */
+async function uidFromPassword(email: string, password: string): Promise<string> {
+  const apiKey = symposiumWebApiKey.value();
+  if (!apiKey) throw new HttpsError('internal', 'Auth API key is not configured');
+
+  try {
+    await axios.post(
+      `https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=${apiKey}`,
+      { email, password, returnSecureToken: true },
+      { timeout: 10000 }
+    );
+  } catch {
+    throw new HttpsError('permission-denied', 'Invalid email or password');
+  }
+
+  const user = await admin.auth().getUserByEmail(email).catch(() => null);
+  if (!user) throw new HttpsError('not-found', 'No account found for this email');
+  return user.uid;
+}
+
+async function uidFromGoogle(idToken: string): Promise<string> {
+  const clientId = googleOAuthClientId.value();
+  if (!clientId) throw new HttpsError('internal', 'Google client ID is not configured');
+
+  let sub: string | undefined;
+  let email: string | undefined;
+  try {
+    const client = new OAuth2Client(clientId);
+    const ticket = await client.verifyIdToken({ idToken, audience: clientId });
+    const payload = ticket.getPayload();
+    sub = payload?.sub;
+    email = payload?.email ?? undefined;
+  } catch {
+    throw new HttpsError('permission-denied', 'Invalid Google credential');
+  }
+  if (!sub) throw new HttpsError('permission-denied', 'Invalid Google credential');
+  return resolveUid('google.com', sub, email);
+}
+
+async function uidFromApple(idToken: string): Promise<string> {
+  const serviceId = appleServiceId.value();
+  if (!serviceId) throw new HttpsError('internal', 'Apple service ID is not configured');
+
+  let sub: string | undefined;
+  let email: string | undefined;
+  try {
+    const { payload } = await jwtVerify(idToken, APPLE_JWKS, {
+      issuer: 'https://appleid.apple.com',
+      audience: serviceId,
+    });
+    sub = typeof payload.sub === 'string' ? payload.sub : undefined;
+    email = typeof payload.email === 'string' ? payload.email : undefined;
+  } catch {
+    throw new HttpsError('permission-denied', 'Invalid Apple credential');
+  }
+  if (!sub) throw new HttpsError('permission-denied', 'Invalid Apple credential');
+  return resolveUid('apple.com', sub, email);
+}
+
+async function resolveUid(providerId: string, providerUid: string, email?: string): Promise<string> {
+  const byProvider = await admin.auth().getUserByProviderUid(providerId, providerUid).catch(() => null);
+  if (byProvider) return byProvider.uid;
+
+  if (email) {
+    const byEmail = await admin.auth().getUserByEmail(email).catch(() => null);
+    if (byEmail) return byEmail.uid;
+  }
+  throw new HttpsError('not-found', 'No account found for this credential');
+}
+
+interface RedeemRequest {
+  method?: 'password' | 'google' | 'apple';
+  code?: string;
+  email?: string;
+  password?: string;
+  idToken?: string;
+}
+
+/**
+ * redeemBackupCode (unauthenticated — the user can't complete 2FA).
+ *
+ * Verifies the first factor, consumes a one-time backup code, and returns a
+ * Firebase custom token. The client signs in with signInWithCustomToken, which
+ * legitimately bypasses the second factor for this single sign-in.
+ */
+export const redeemBackupCode = onCall(
+  { secrets: [symposiumWebApiKey, googleOAuthClientId, appleServiceId] },
+  async (request): Promise<{ token: string }> => {
+    const { method, code, email, password, idToken } = (request.data ?? {}) as RedeemRequest;
+
+    if (!code || typeof code !== 'string') {
+      throw new HttpsError('invalid-argument', 'A backup code is required');
+    }
+
+    let uid: string;
+    if (method === 'password') {
+      if (!email || !password) {
+        throw new HttpsError('invalid-argument', 'Email and password are required');
+      }
+      uid = await uidFromPassword(email, password);
+    } else if (method === 'google') {
+      if (!idToken) throw new HttpsError('invalid-argument', 'Google credential is required');
+      uid = await uidFromGoogle(idToken);
+    } else if (method === 'apple') {
+      if (!idToken) throw new HttpsError('invalid-argument', 'Apple credential is required');
+      uid = await uidFromApple(idToken);
+    } else {
+      throw new HttpsError('invalid-argument', 'Unsupported sign-in method');
+    }
+
+    const consumed = await verifyAndConsumeBackupCode(uid, code);
+    if (!consumed) {
+      throw new HttpsError('permission-denied', 'Invalid or already-used backup code');
+    }
+
+    const token = await admin.auth().createCustomToken(uid);
+    return { token };
+  }
+);

--- a/functions/src/testApiKey.ts
+++ b/functions/src/testApiKey.ts
@@ -1,0 +1,198 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { encryptionKey, getDecryptedApiKey } from './apiKeys';
+
+/**
+ * testApiKey
+ *
+ * Validates a provider API key by making a minimal, authenticated probe to the
+ * provider — WITHOUT ever returning or logging the key. Tests either a key
+ * passed by the client (before saving) or, when `apiKey` is omitted, the user's
+ * stored encrypted key.
+ *
+ * Strategy: prefer each provider's model-list GET endpoint (no model-id
+ * coupling, no token cost). Interpretation is uniform: 401/403 => invalid key,
+ * 2xx/429 => valid. Perplexity has no models endpoint, so it uses a tiny
+ * completion and additionally treats 400 (bad request, auth passed) as valid.
+ */
+
+interface ProbeResult {
+  ok: boolean;
+  message?: string;
+  detail?: string;
+}
+
+interface ProviderProbe {
+  request: (key: string) => { url: string; init: RequestInit };
+  /** Completion-style probes can return 400 with a valid key (e.g. model drift). */
+  treat400AsValid?: boolean;
+}
+
+const ANTHROPIC_VERSION = '2023-06-01';
+
+const PROBES: Record<string, ProviderProbe> = {
+  claude: {
+    request: (key) => ({
+      url: 'https://api.anthropic.com/v1/models',
+      init: { method: 'GET', headers: { 'x-api-key': key, 'anthropic-version': ANTHROPIC_VERSION } },
+    }),
+  },
+  openai: {
+    request: (key) => ({
+      url: 'https://api.openai.com/v1/models',
+      init: { method: 'GET', headers: { Authorization: `Bearer ${key}` } },
+    }),
+  },
+  google: {
+    request: (key) => ({
+      url: `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(key)}`,
+      init: { method: 'GET' },
+    }),
+  },
+  mistral: {
+    request: (key) => ({
+      url: 'https://api.mistral.ai/v1/models',
+      init: { method: 'GET', headers: { Authorization: `Bearer ${key}` } },
+    }),
+  },
+  deepseek: {
+    request: (key) => ({
+      url: 'https://api.deepseek.com/models',
+      init: { method: 'GET', headers: { Authorization: `Bearer ${key}` } },
+    }),
+  },
+  grok: {
+    request: (key) => ({
+      url: 'https://api.x.ai/v1/models',
+      init: { method: 'GET', headers: { Authorization: `Bearer ${key}` } },
+    }),
+  },
+  cohere: {
+    request: (key) => ({
+      url: 'https://api.cohere.ai/v1/models',
+      init: { method: 'GET', headers: { Authorization: `Bearer ${key}` } },
+    }),
+  },
+  perplexity: {
+    request: (key) => ({
+      url: 'https://api.perplexity.ai/chat/completions',
+      init: {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'sonar',
+          messages: [{ role: 'user', content: 'ping' }],
+          max_tokens: 1,
+        }),
+      },
+    }),
+    treat400AsValid: true,
+  },
+  brave: {
+    request: (key) => ({
+      url: 'https://api.search.brave.com/res/v1/web/search?q=ping&count=1',
+      init: { method: 'GET', headers: { 'X-Subscription-Token': key, Accept: 'application/json' } },
+    }),
+  },
+  elevenlabs: {
+    request: (key) => ({
+      url: 'https://api.elevenlabs.io/v1/user',
+      init: { method: 'GET', headers: { 'xi-api-key': key } },
+    }),
+  },
+};
+
+const PROBE_TIMEOUT_MS = 10000;
+
+async function probeProvider(providerId: string, key: string): Promise<ProbeResult> {
+  const probe = PROBES[providerId];
+  if (!probe) {
+    return { ok: false, message: 'Connection testing is not available for this provider.' };
+  }
+
+  const { url, init } = probe.request(key);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(url, { ...init, signal: controller.signal });
+  } catch (error) {
+    const message = error instanceof Error && error.name === 'AbortError'
+      ? 'The provider did not respond in time. Please try again.'
+      : 'Could not reach the provider. Check your connection and try again.';
+    return { ok: false, message };
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const status = response.status;
+
+  if (status === 401 || status === 403) {
+    return { ok: false, message: 'Invalid API key.', detail: await snippet(response) };
+  }
+  if ((status >= 200 && status < 300) || status === 429) {
+    return { ok: true, message: status === 429 ? 'Key verified (rate limited).' : 'Key verified.' };
+  }
+  if (status === 400 && probe.treat400AsValid) {
+    return { ok: true, message: 'Key verified.' };
+  }
+
+  return {
+    ok: false,
+    message: `Unexpected response from provider (HTTP ${status}).`,
+    detail: await snippet(response),
+  };
+}
+
+/** Short, key-free excerpt of a provider error body for diagnostics. */
+async function snippet(response: Response): Promise<string | undefined> {
+  try {
+    const text = await response.text();
+    if (!text) return undefined;
+    return text.replace(/\s+/g, ' ').trim().slice(0, 200);
+  } catch {
+    return undefined;
+  }
+}
+
+export const testApiKey = onCall(
+  { secrets: [encryptionKey] },
+  async (request): Promise<ProbeResult> => {
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Must be authenticated to test API keys');
+    }
+
+    const { providerId, apiKey } = request.data ?? {};
+
+    if (!providerId || typeof providerId !== 'string') {
+      throw new HttpsError('invalid-argument', 'Provider ID is required');
+    }
+    if (!PROBES[providerId]) {
+      return { ok: false, message: 'Connection testing is not available for this provider.' };
+    }
+
+    // Determine which key to test: the supplied one, or the stored encrypted key.
+    let keyToTest: string;
+    if (apiKey !== undefined && apiKey !== null && apiKey !== '') {
+      if (typeof apiKey !== 'string') {
+        throw new HttpsError('invalid-argument', 'API key must be a string');
+      }
+      keyToTest = apiKey.trim();
+      if (keyToTest.length < 10 || keyToTest.length > 500) {
+        throw new HttpsError('invalid-argument', 'API key has invalid length');
+      }
+    } else {
+      const keyValue = encryptionKey.value();
+      if (!keyValue) {
+        throw new HttpsError('internal', 'Encryption not configured');
+      }
+      const stored = await getDecryptedApiKey(request.auth.uid, providerId, keyValue);
+      if (!stored) {
+        return { ok: false, message: 'No API key is saved for this provider yet.' };
+      }
+      keyToTest = stored;
+    }
+
+    return probeProvider(providerId, keyToTest);
+  }
+);


### PR DESCRIPTION
Backend for the web Settings redesign (companion: **Braveheart-Innovations/symposiumai-web#177**). All four callables are **already deployed** to `symposium-ai`/us-central1 via `firebase deploy --only functions:<name>`; this PR brings master in sync with what's live.

## New callables
- **`testApiKey(providerId, apiKey?)`** → `{ ok, message?, detail? }` — validates a provider key via a minimal authenticated probe (model-list GET for claude/openai/google/mistral/deepseek/grok/cohere; brave/elevenlabs; perplexity completion). `401/403 → invalid`, `2xx/429 → valid`. Never echoes the key; tests the supplied key or decrypts the stored one.
- **`generateBackupCodes()` / `getBackupCodesStatus()`** — single-use 2FA recovery codes stored as per-code salted scrypt hashes at `users/{uid}/security/backupCodes` (auto-wiped by `deleteAccount`).
- **`redeemBackupCode({ method, code, ... })`** — unauthenticated lockout recovery: verifies the first factor (password via `SYMPOSIUM_WEB_API_KEY`; Google via `OAuth2Client` + `GOOGLE_OAUTH_CLIENT_ID`; Apple via `jose` + `APPLE_SERVICE_ID`), consumes a code, and returns a custom token the client uses with `signInWithCustomToken`. Also exports `verifyAndConsumeBackupCode()`.

## Deploy/config already applied (prod)
- TOTP MFA enabled on the project; `GOOGLE_OAUTH_CLIENT_ID` secret created.
- `roles/iam.serviceAccountTokenCreator` granted to the gen2 runtime SA (`248794683640-compute@…`) — required for `createCustomToken` (first use of custom tokens here).

## Verification
- `tsc --noEmit` + eslint clean on the new files.
- Google → 2FA → backup-code sign-in confirmed end-to-end against the deployed functions.

## Follow-up (non-blocking)
- Add a per-uid rate limit to `redeemBackupCode` (defense-in-depth; already gated by first factor + ~31⁸ code space).

🤖 Generated with [Claude Code](https://claude.com/claude-code)