### PR TITLE
fix(deps): override websocket-driver to 0.7.5 (patch RTDB WS advisories)

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -5517,9 +5517,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -47,6 +47,7 @@
     "@protobufjs/utf8": "^1.1.1",
     "basic-ftp": "^6.0.1",
     "fast-xml-builder": "^1.2.0",
-    "ip-address": "^10.2.0"
+    "ip-address": "^10.2.0",
+    "websocket-driver": "^0.7.5"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17206,9 +17206,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,8 @@
     "postcss": "^8.5.10",
     "uuid": "^14.0.0",
     "protobufjs": "^7.5.8",
-    "@protobufjs/utf8": "^1.1.1"
+    "@protobufjs/utf8": "^1.1.1",
+    "websocket-driver": "^0.7.5"
   },
   "private": true
 }


### PR DESCRIPTION
## What
Pin `websocket-driver` to **0.7.5** via `overrides` in both the root and `functions/` `package.json`, regenerating both lockfiles.

## Why
`websocket-driver` arrives transitively through `faye-websocket → @firebase/database`, whose `">=0.5.1"` range let npm keep resolving the vulnerable **0.7.4**. That's why the plain Dependabot bumps (#116/#117) stayed red on `dependency-scan` — the resolver landed back on 0.7.4. The `overrides` clamp forces 0.7.5 across both trees.

## Verification
- `npm audit` — **0 vulnerabilities** in root and `functions/`
- `npm ls websocket-driver` — resolves **0.7.5** in both trees (via `faye-websocket`)
- `npm run check:app` — typecheck, lint, any-budget, and 4275 tests all pass

## Closes Dependabot alerts
- **GHSA-xv26-6w52-cph6** (critical) — message corruption via protocol length headers (#180, #181)
- **GHSA-mp7j-qc5w-4988** (medium) — resource-limit bypass via message compression (#182, #183)

Supersedes #116 and #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)