### PR TITLE
chore: commit live Stripe config (price ids + prod URL)

### DIFF
--- a/functions/.env.symposium-ai
+++ b/functions/.env.symposium-ai
@@ -1,0 +1,11 @@
+# Non-secret Stripe config for the `symposium-ai` Firebase project.
+# Loaded automatically by Firebase Functions at deploy/runtime (process.env.*).
+# Live production price ids + the web origin used for Stripe redirect URLs.
+#
+# Do NOT put secrets here (secret keys, webhook signing secrets). Those live in
+# Google Secret Manager via defineSecret and are set with:
+#   firebase functions:secrets:set STRIPE_SECRET_KEY --project symposium-ai
+#   firebase functions:secrets:set STRIPE_WEBHOOK_SECRET --project symposium-ai
+STRIPE_PRICE_MONTHLY=price_1SiqyVEkPKYlBuPsJcmUP7yo
+STRIPE_PRICE_ANNUAL=price_1SiqzMEkPKYlBuPsqqdrYhnw
+APP_BASE_URL=https://app.symposiumai.app


### PR DESCRIPTION
Persists the non-secret Stripe config that was set at deploy time when the web app went live, so a fresh checkout + redeploy can't silently revert to the test-mode price defaults hardcoded in `stripe.ts`.

- `functions/.env.symposium-ai`: live `STRIPE_PRICE_MONTHLY` / `STRIPE_PRICE_ANNUAL` + `APP_BASE_URL=https://app.symposiumai.app`
- Loaded automatically by Firebase Functions at deploy/runtime.
- **No secrets here** — `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` stay in Secret Manager.

Already live in production; this just puts the config under version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)