### PR TITLE
chore: v2.0 release prep — remote versioning + axios security patch + checklist

### DIFF
--- a/app.json
+++ b/app.json
@@ -51,7 +51,7 @@
       },
       "package": "com.braveheartinnovations.debateai",
       "googleServicesFile": "./google-services.json",
-      "versionCode": 37
+      "versionCode": 38
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/app.json
+++ b/app.json
@@ -14,7 +14,7 @@
       "backgroundColor": "#1A1A1A"
     },
     "ios": {
-      "buildNumber": "28",
+      "buildNumber": "29",
       "supportsTablet": true,
       "bundleIdentifier": "com.braveheartinnovations.debateai",
       "googleServicesFile": "./GoogleService-Info.plist",
@@ -51,7 +51,7 @@
       },
       "package": "com.braveheartinnovations.debateai",
       "googleServicesFile": "./google-services.json",
-      "versionCode": 38
+      "versionCode": 39
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/docs/STORE_SUBMISSION_CHECKLIST.md
+++ b/docs/STORE_SUBMISSION_CHECKLIST.md
@@ -1,7 +1,7 @@
 # Store Submission Checklist
 ## Symposium AI React Native App
 
-*Last Updated: December 2025*
+*Last Updated: July 2026 — v2.0.0 submission*
 
 ---
 
@@ -43,36 +43,39 @@
 
 ### 2. Version Information
 
-#### What's New (Version 1.2.3)
+#### What's New (Version 2.0.0)
 ```
-Welcome to Symposium AI - Where Ideas Converge!
+Symposium AI 2.0 — our biggest update yet.
 
-• AI Debate Arena: Watch different AIs debate any topic
-• Chat with multiple AI providers simultaneously
-• BYOK: Use your own API keys securely
-• Hallucination Shield: AIs fact-check each other
-• 12 unique personalities per AI
-• Expert Mode for advanced users
-• Beautiful light/dark themes
-• Premium features with subscription or lifetime purchase
+• Composer-first redesign: start any chat, comparison, or creation right from the prompt bar, with pill-based AI selection
+• Create Studio: generate images, video, and audio with multiple AI providers — now with a media gallery and instant previews
+• Real-time web search with cited sources (Claude and Grok)
+• Attach images and documents before your first message
+• Refreshed July 2026 model catalog: Claude Sonnet 5, GPT-5.6, Grok 4.5, and more
+• Expert Mode: model-aware parameter controls
+• ElevenLabs voice library for debates and audio
+• Smoother keyboard handling and many UI refinements
 
 Your API keys stay private and secure on your device.
 ```
 
 #### Version Details
-- [x] Version Number: `1.2.3`
-- [x] Build Number: `2`
-- [x] Copyright: `© 2025 Braveheart Innovations LLC`
+- [x] Version Number: `2.0.0`
+- [x] Build Number: `28` (iOS) · Android versionCode `37`
+- [x] Copyright: `© 2026 Braveheart Innovations LLC`
 
 ### 3. App Preview and Screenshots
 
-#### Screenshots Required (6.7", 6.5", 5.5")
-1. [x] Welcome screen showing key features
-2. [x] Chat interface with multiple AIs
-3. [x] AI Debate in action
-4. [x] Personality selection screen
-5. [x] Expert mode with model selection
-6. [x] Premium upgrade screen
+#### Screenshots — REFRESH for v2.0 UI (verify current required sizes; 6.9"/6.7" iPhone + 13" iPad)
+1. [ ] Composer-first Home / Chat entry (new prompt-bar flow)
+2. [ ] Multi-AI chat conversation
+3. [ ] AI Debate Arena in action
+4. [ ] Create Studio — image/video/audio with gallery previews
+5. [ ] Web search with cited sources
+6. [ ] Expert Mode / model selection
+7. [ ] Premium upgrade screen
+
+> v1.x screenshots are stale — the composer-first redesign and Create Studio changed these screens. Re-capture before submitting.
 
 #### App Preview Video (Optional but Recommended)
 - [ ] 15-30 seconds
@@ -217,7 +220,7 @@ ai,chat,gpt,claude,gemini,chatbot,debate,arena,conversation,api,keys,byok,premiu
 
 #### Promotional Text (170 characters)
 ```
-Watch AIs debate any topic! Chat with Claude, ChatGPT, and Gemini simultaneously. Use your own API keys for maximum savings. Premium unlocks custom debates and more.
+Debate AIs; chat Claude, ChatGPT & Gemini at once; create images, video & audio; web search with citations. Bring your own API keys and save. Premium unlocks more.
 ```
 
 ### 10. Final Submission

--- a/eas.json
+++ b/eas.json
@@ -1,6 +1,6 @@
 {
   "cli": {
-    "appVersionSource": "local",
+    "appVersionSource": "remote",
     "version": ">= 5.0.0"
   },
   "build": {
@@ -24,6 +24,7 @@
       "node": "22.17.0",
       "developmentClient": false,
       "distribution": "store",
+      "autoIncrement": true,
       "channel": "internal-testing",
       "env": {
         "EXPO_PUBLIC_RELEASE_CHANNEL": "internal",
@@ -39,6 +40,7 @@
       "node": "22.17.0",
       "developmentClient": false,
       "distribution": "store",
+      "autoIncrement": true,
       "channel": "beta",
       "env": {
         "EXPO_PUBLIC_RELEASE_CHANNEL": "beta",
@@ -73,6 +75,7 @@
       "node": "22.17.0",
       "developmentClient": false,
       "distribution": "store",
+      "autoIncrement": true,
       "channel": "production",
       "env": {
         "EXPO_PUBLIC_RELEASE_CHANNEL": "production",

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1291,9 +1291,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -2089,7 +2089,8 @@
       "version": "0.0.1566079",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.4.11",
@@ -2612,6 +2613,7 @@
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.8.0.tgz",
       "integrity": "sha512-iawoQkmZbsA+2DY5UEuB8f6jSlskzzySoye0D2F6e3zlDZX9DUcXf0HhZqLUn/P6WhLGvTf6ZtCmshZvhAgTYg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
         "@firebase/database-compat": "^2.0.0",
@@ -4909,6 +4911,7 @@
       "resolved": "https://registry.npmjs.org/vega/-/vega-6.2.0.tgz",
       "integrity": "sha512-BIwalIcEGysJdQDjeVUmMWB3e50jPDNAMfLJscjEvpunU9bSt7X1OYnQxkg3uBwuRRI4nWfFZO9uIW910nLeGw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "vega-crossfilter": "~5.1.0",
         "vega-dataflow": "~6.1.0",
@@ -5118,6 +5121,7 @@
       "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-6.4.2.tgz",
       "integrity": "sha512-Mv2PaRIpijz256LM0NdOJd9Md8cqyrXina54xW6Qp865YfY502zlXGUst+W/XznVwISGfatt0yLZuDqCUbBDuw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "json-stringify-pretty-compact": "~4.0.0",
         "tslib": "~2.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6306,9 +6306,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",


### PR DESCRIPTION
Bundled v2.0 release-prep changes (all needed to get this branch green + submitted):

### 1. Android versionCode unblock
Bump `versionCode` 37 → 38 (37 was already on Play). v2.0 Android submission succeeded with 38.

### 2. Remote EAS versioning (the durable fix)
`eas.json` → `appVersionSource: "remote"` + `autoIncrement` on production/beta/internal-testing. Ends the recurring "version already submitted" failures — EAS auto-increments from the store. Seeds bumped to `versionCode 39` / `buildNumber 29`.

### 3. axios security patch (CI unblock)
Newly-published moderate advisories (GHSA-42h9-826w-cgv3, GHSA-xj6q-8x83-jv6g, GHSA-pmv8-rq9r-6j72) flagged axios 1.16.1 in **root and functions/**, failing `dependency-scan` repo-wide. Patched to 1.18.1 (within `^1.13` range). `npm audit` clean, `check:app` green (4273 tests).

### 4. Docs
Refreshed `STORE_SUBMISSION_CHECKLIST.md` for v2.0 (What's New, versions, screenshots, promo text).

## v2.0 submission status
- iOS 2.0.0 (28) → App Store Connect ✅
- Android 2.0.0 (38) → Play production (draft) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)