### PR TITLE
fix: [create] - reset finished session cards when leaving Create

### DIFF
--- a/__tests__/screens/CreateSetupScreen.test.tsx
+++ b/__tests__/screens/CreateSetupScreen.test.tsx
@@ -348,6 +348,7 @@ jest.mock('@/store/createSlice', () => ({
   hydrateGallery: jest.fn(() => ({ type: 'create/hydrateGallery' })),
   hydrateMediaGallery: jest.fn(() => ({ type: 'create/hydrateMediaGallery' })),
   backfillVideoThumbnails: jest.fn(() => ({ type: 'create/backfillVideoThumbnails' })),
+  clearFinishedGenerations: jest.fn(() => ({ type: 'create/clearFinishedGenerations' })),
   generateCreateVideo: jest.fn((payload) => ({ type: 'create/generateCreateVideo', payload, unwrap: jest.fn() })),
   generateCreateAudio: jest.fn((payload) => ({ type: 'create/generateCreateAudio', payload, unwrap: jest.fn() })),
   selectCreateState: (state: any) => state.create,

--- a/__tests__/store/createSlice.test.ts
+++ b/__tests__/store/createSlice.test.ts
@@ -39,6 +39,7 @@ import reducer, {
   completeGeneration,
   generationError,
   clearGenerationError,
+  clearFinishedGenerations,
   setActiveCreateTab,
   markCreateActivitySeen,
   startMediaGeneration,
@@ -237,6 +238,70 @@ describe('createSlice', () => {
         message: 'openai: unsupported source image',
       });
       expect(state.createActivity.status).toBe('failed');
+    });
+  });
+
+  describe('clearFinishedGenerations', () => {
+    it('clears a completed image result so Create returns to a fresh empty state', () => {
+      let state = reducer(initialState, startImageGeneration({
+        id: 'image_generation_1',
+        providers: ['openai'],
+        prompt: 'A clean product image',
+      }));
+      state = reducer(state, completeImageGeneration({
+        resultIds: ['img_1'],
+        message: 'Image generation complete.',
+      }));
+      expect(state.lastImageGenerationResult).toBeDefined();
+
+      state = reducer(state, clearFinishedGenerations());
+      expect(state.imageGeneration).toBeNull();
+      expect(state.lastImageGenerationResult).toBeUndefined();
+    });
+
+    it('clears a completed media result', () => {
+      let state = reducer(initialState, startMediaGeneration({
+        id: 'generation_1',
+        mediaType: 'video',
+        providerId: 'runway',
+        operation: 'text_to_video',
+        modelId: 'gen4.5',
+        prompt: 'A city at sunrise',
+      }));
+      state = reducer(state, completeMediaGeneration({
+        mediaType: 'video',
+        status: 'succeeded',
+        message: 'Video generation complete.',
+        resultId: 'vid_1',
+      }));
+      expect(state.lastMediaGenerationResult).toBeDefined();
+
+      state = reducer(state, clearFinishedGenerations());
+      expect(state.mediaGeneration.video).toBeNull();
+      expect(state.lastMediaGenerationResult).toBeUndefined();
+    });
+
+    it('preserves an in-flight image generation', () => {
+      let state = reducer(initialState, startImageGeneration({
+        id: 'image_generation_1',
+        providers: ['openai'],
+        prompt: 'Still generating',
+      }));
+      state = reducer(state, clearFinishedGenerations());
+      expect(state.imageGeneration).not.toBeNull();
+    });
+
+    it('preserves an in-flight media generation', () => {
+      let state = reducer(initialState, startMediaGeneration({
+        id: 'generation_1',
+        mediaType: 'video',
+        providerId: 'runway',
+        operation: 'text_to_video',
+        modelId: 'gen4.5',
+        prompt: 'Still rendering',
+      }));
+      state = reducer(state, clearFinishedGenerations());
+      expect(state.mediaGeneration.video).not.toBeNull();
     });
   });
 

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1542,9 +1542,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4020,9 +4020,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1591,9 +1591,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1672,9 +1672,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4461,9 +4461,9 @@
       "license": "MIT"
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4954,9 +4954,9 @@
       "license": "MIT"
     },
     "node_modules/@react-native/babel-plugin-codegen/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5083,9 +5083,9 @@
       "license": "MIT"
     },
     "node_modules/@react-native/codegen/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6670,9 +6670,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -8217,9 +8217,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8278,9 +8278,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10972,9 +10972,9 @@
       "license": "MIT"
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11425,9 +11425,9 @@
       "license": "MIT"
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14195,9 +14195,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -15033,9 +15033,9 @@
       "license": "MIT"
     },
     "node_modules/react-native/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -15485,9 +15485,9 @@
       "license": "MIT"
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -15905,9 +15905,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -16585,9 +16585,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/src/screens/CreateSetupScreen.tsx
+++ b/src/screens/CreateSetupScreen.tsx
@@ -10,7 +10,7 @@ import {
   StyleSheet,
   Alert,
 } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useSelector, useDispatch } from 'react-redux';
@@ -53,6 +53,7 @@ import {
   backfillVideoThumbnails,
   generateCreateVideo,
   generateCreateAudio,
+  clearFinishedGenerations,
   selectCreateState,
 } from '../store/createSlice';
 import { useCreateComposerSelection } from '../hooks/create/useCreateComposerSelection';
@@ -199,6 +200,15 @@ export default function CreateSetupScreen() {
       dispatch(backfillVideoThumbnails());
     }
   }, [dispatch, mediaGalleryHydrated, isDemo]);
+
+  // When leaving Create, clear the finished "session complete" result cards so
+  // returning starts fresh on the empty state (the RECENT strip persists). An
+  // in-flight generation is preserved by the reducer's guard.
+  useFocusEffect(
+    useCallback(() => () => {
+      dispatch(clearFinishedGenerations());
+    }, [dispatch])
+  );
 
   // ---------------------------------------------------------------- image tab
 

--- a/src/store/createSlice.ts
+++ b/src/store/createSlice.ts
@@ -1561,6 +1561,26 @@ const createSlice_ = createSlice({
     clearGenerationError: (state) => {
       state.generationError = undefined;
     },
+    clearFinishedGenerations: (state) => {
+      // Reset the transient "session complete" result cards so returning to
+      // Create starts fresh (matching the post-reboot experience). The
+      // persisted gallery/mediaGallery (the RECENT strip) is left untouched,
+      // and an in-flight generation is never disturbed.
+      const imageInFlight =
+        state.isGenerating ||
+        (state.imageGeneration != null &&
+          state.imageGeneration.status !== 'succeeded' &&
+          state.imageGeneration.status !== 'failed');
+      const mediaInFlight =
+        state.mediaGeneration.video != null || state.mediaGeneration.audio != null;
+      if (imageInFlight || mediaInFlight) return;
+
+      state.imageGeneration = null;
+      state.mediaGeneration.video = null;
+      state.mediaGeneration.audio = null;
+      state.lastImageGenerationResult = undefined;
+      state.lastMediaGenerationResult = undefined;
+    },
 
     // Gallery management
     addToGallery: (state, action: PayloadAction<GeneratedImageEntry>) => {
@@ -1744,6 +1764,7 @@ export const {
   completeGeneration,
   generationError,
   clearGenerationError,
+  clearFinishedGenerations,
   addToGallery,
   updateGalleryEntryUri,
   removeFromGallery,


### PR DESCRIPTION
## Bug
In Create mode, after a session completes the result card ("2 images generated / View in Gallery", "Video generation complete") stayed pinned no matter where you navigated — only an app restart cleared it back to the fresh entry state.

## Cause
The result cards render off `imageGeneration`/`mediaGeneration` + their `lastXResult` snapshots in the Redux `create` slice — in-memory state that survives tab navigation but is dropped on restart (hence reboot "fixed" it). Nothing reset them on navigation.

## Fix
- New guarded reducer `clearFinishedGenerations` — nulls the transient result state, but bails if a generation is in-flight (`isGenerating` or any active `mediaGeneration[type]`). Persisted `gallery`/`mediaGallery` (RECENT strip) untouched.
- `CreateSetupScreen` dispatches it on blur (`useFocusEffect` cleanup) → returning to Create shows the fresh empty state, matching post-reboot.

## Tests
4 new reducer cases (clears completed image/media, preserves in-flight image/media); test mock updated. `check:app` green (4277).

🤖 Generated with [Claude Code](https://claude.com/claude-code)