### PR TITLE
fix: [claude] - place citation chips after cited spans, dedupe per block

### DIFF
--- a/src/services/ai/adapters/__tests__/ClaudeAdapter.test.ts
+++ b/src/services/ai/adapters/__tests__/ClaudeAdapter.test.ts
@@ -271,6 +271,12 @@ describe('ClaudeAdapter', () => {
                 title: 'Source A',
                 cited_text: 'the news',
               },
+              {
+                type: 'web_search_result_location',
+                url: 'https://example.com/a',
+                title: 'Source A',
+                cited_text: 'summary',
+              },
             ],
           },
         ],
@@ -281,7 +287,8 @@ describe('ClaudeAdapter', () => {
     const adapter = new ClaudeAdapter({ ...makeConfig('claude-sonnet-5'), webSearchEnabled: true });
     const result = await adapter.sendMessage('What happened today?');
 
-    // A [1] marker is injected after the cited span for inline chip rendering.
+    // One [1] marker after the cited span — repeat citations of a source
+    // within a block collapse to a single chip.
     expect(result).toEqual(expect.objectContaining({
       response: 'Latest news summary.[1]',
       metadata: {
@@ -373,12 +380,10 @@ describe('ClaudeAdapter', () => {
         content: [{ type: 'web_search_result', url: 'https://example.com/b', title: 'Source B' }],
       },
     }));
-    eventSource.emit('content_block_delta', JSON.stringify({ delta: { text: 'Answer' } }));
-    await expect(firstChunk).resolves.toEqual({ value: 'Answer', done: false });
-
-    // The citations_delta injects a bare [1] marker into the text stream.
-    const markerChunk = iterator.next();
-    eventSource.emit('content_block_delta', JSON.stringify({
+    // Live streams deliver citations_delta before the cited block's text, and
+    // a block can cite the same source twice; the [1] marker must still land
+    // once, after the block's text, when the block closes.
+    const citationsDelta = {
       delta: {
         type: 'citations_delta',
         citation: {
@@ -388,7 +393,14 @@ describe('ClaudeAdapter', () => {
           cited_text: 'cited passage',
         },
       },
-    }));
+    };
+    eventSource.emit('content_block_delta', JSON.stringify(citationsDelta));
+    eventSource.emit('content_block_delta', JSON.stringify(citationsDelta));
+    eventSource.emit('content_block_delta', JSON.stringify({ delta: { text: 'Answer' } }));
+    await expect(firstChunk).resolves.toEqual({ value: 'Answer', done: false });
+
+    const markerChunk = iterator.next();
+    eventSource.emit('content_block_stop', JSON.stringify({}));
     await expect(markerChunk).resolves.toEqual({ value: '[1]', done: false });
 
     const finalChunk = iterator.next();

--- a/src/services/ai/adapters/claude/ClaudeAdapter.ts
+++ b/src/services/ai/adapters/claude/ClaudeAdapter.ts
@@ -80,13 +80,16 @@ export class ClaudeAdapter extends BaseAdapter {
       if ((b.type === undefined || b.type === 'text') && typeof b.text === 'string') {
         text += b.text;
         if (Array.isArray(b.citations)) {
+          // A block citing one source several times still gets a single chip.
+          const blockIndices = new Set<number>();
           for (const c of b.citations) {
             const cit = c as { type?: string; url?: unknown; title?: unknown; cited_text?: unknown } | null;
             if (cit && cit.type === 'web_search_result_location') {
               const index = add(cit.url, cit.title, cit.cited_text);
-              if (index !== undefined) text += `[${index}]`;
+              if (index !== undefined) blockIndices.add(index);
             }
           }
+          for (const index of blockIndices) text += `[${index}]`;
         }
       }
     }
@@ -343,13 +346,22 @@ export class ClaudeAdapter extends BaseAdapter {
     };
 
     // Web-search citations accumulated over the stream: citations_delta is the
-    // primary source; web_search_tool_result blocks are the URL fallback. A
-    // bare [n] marker is injected into the text when each citation lands so the
-    // app renders inline chips as well as the source table.
+    // primary source; web_search_tool_result blocks are the URL fallback.
     const streamCitations: Array<{ index: number; url: string; title?: string; snippet?: string }> = [];
     const fallbackCitations: Array<{ index: number; url: string; title?: string }> = [];
     const citationIndexByUrl = new Map<string, number>();
     const seenFallbackUrls = new Set<string>();
+    // Indices cited by the in-flight text block. citations_delta can arrive
+    // before the block's text deltas, so markers are buffered here and flushed
+    // as bare [n] chips at content_block_stop — after the cited span — with the
+    // Set collapsing repeat citations of one source within a block.
+    const pendingBlockCitations = new Set<number>();
+    const flushBlockCitations = () => {
+      if (pendingBlockCitations.size === 0) return;
+      const markers = Array.from(pendingBlockCitations, (i) => `[${i}]`).join('');
+      pendingBlockCitations.clear();
+      emitText(markers);
+    };
     const emitCitations = () => {
       const citations = streamCitations.length > 0 ? streamCitations : fallbackCitations;
       if (citations.length > 0 && onEvent) {
@@ -380,8 +392,7 @@ export class ClaudeAdapter extends BaseAdapter {
                 ...(typeof citation?.cited_text === 'string' && citation.cited_text ? { snippet: citation.cited_text } : {}),
               });
             }
-            // Inject the inline marker after the text it annotates.
-            emitText(`[${index}]`);
+            pendingBlockCitations.add(index);
           }
         }
 
@@ -396,11 +407,15 @@ export class ClaudeAdapter extends BaseAdapter {
     
     // Mark content block completion (sometimes message_stop can be delayed)
     es.addEventListener('content_block_stop', (event: CustomEvent<'content_block_stop'>) => {
+      flushBlockCitations();
       try { if (onEvent) onEvent({ type: 'content_block_stop', ...(event?.data ? JSON.parse(event.data) : {}) }); } catch { /* noop */ }
     });
-    
+
     // Handle message_stop event for stream completion
     es.addEventListener('message_stop', () => {
+      // Safety net in case the final content_block_stop never arrived; the
+      // generator drains queued text before honoring isComplete.
+      flushBlockCitations();
       // Citations must surface before the generator resolves done so the
       // orchestrator captures them into message metadata.
       emitCitations();


### PR DESCRIPTION
## Summary
Ships a completed fix from July 20 that was committed locally but never pushed — surfaced during branch-hygiene audit. Claude web-search citation chips now render after the span they cite instead of clustering, and duplicate citations within a block are deduped (ClaudeAdapter + tests).

## Test plan
- [x] ClaudeAdapter unit tests updated/passing in the commit
- [x] CI quality gate (full suite) on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)