### PR TITLE
feat: add Moonshot (Kimi) and Z.ai (GLM) providers to the AI proxy

### DIFF
--- a/.github/workflows/live-model-routing.yml
+++ b/.github/workflows/live-model-routing.yml
@@ -61,3 +61,5 @@ jobs:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
+          MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
+          ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}

--- a/functions/src/aiProxy.ts
+++ b/functions/src/aiProxy.ts
@@ -41,6 +41,14 @@ const PROVIDER_CONFIGS: Record<string, {
     baseUrl: 'https://api.x.ai/v1/chat/completions',
     authHeader: 'Authorization',
   },
+  moonshot: {
+    baseUrl: 'https://api.moonshot.ai/v1/chat/completions',
+    authHeader: 'Authorization',
+  },
+  zai: {
+    baseUrl: 'https://api.z.ai/api/paas/v4/chat/completions',
+    authHeader: 'Authorization',
+  },
 };
 
 interface Message {
@@ -183,6 +191,8 @@ const PROVIDER_NAMES: Record<string, string> = {
   cohere: 'Cohere',
   deepseek: 'DeepSeek',
   grok: 'Grok',
+  moonshot: 'Kimi',
+  zai: 'GLM',
 };
 
 /**
@@ -1291,6 +1301,12 @@ function modelSupportsVision(providerId: string, model: string): boolean {
       // Command A Vision model supports vision
       return modelLower.includes('vision') ||
              modelLower.includes('command-a');
+    case 'moonshot':
+      // Kimi K3 and K2.x are natively multimodal
+      return modelLower.includes('kimi-k');
+    case 'zai':
+      // Only the GLM vision line (glm-5v-*) accepts image input
+      return modelLower.includes('glm-5v');
     default:
       // DeepSeek doesn't support vision via their chat API
       return false;

--- a/functions/src/aiProxyStream.ts
+++ b/functions/src/aiProxyStream.ts
@@ -64,6 +64,16 @@ const PROVIDER_CONFIGS: Record<string, {
     authHeader: 'Authorization',
     streamParam: 'stream',
   },
+  moonshot: {
+    baseUrl: 'https://api.moonshot.ai/v1/chat/completions',
+    authHeader: 'Authorization',
+    streamParam: 'stream',
+  },
+  zai: {
+    baseUrl: 'https://api.z.ai/api/paas/v4/chat/completions',
+    authHeader: 'Authorization',
+    streamParam: 'stream',
+  },
 };
 
 interface Message {
@@ -1273,6 +1283,10 @@ function modelSupportsVision(providerId: string, model: string): boolean {
     case 'cohere':
       return modelLower.includes('vision') ||
              modelLower.includes('command-a');
+    case 'moonshot':
+      return modelLower.includes('kimi-k');
+    case 'zai':
+      return modelLower.includes('glm-5v');
     default:
       return false;
   }
@@ -1290,6 +1304,8 @@ const PROVIDER_NAMES: Record<string, string> = {
   cohere: 'Cohere',
   deepseek: 'DeepSeek',
   grok: 'Grok',
+  moonshot: 'Kimi',
+  zai: 'GLM',
 };
 
 /**

--- a/functions/src/aiProxyStreamV2.ts
+++ b/functions/src/aiProxyStreamV2.ts
@@ -177,6 +177,8 @@ const PROVIDER_NAMES: Record<string, string> = {
   deepseek: 'DeepSeek',
   grok: 'Grok',
   cohere: 'Cohere',
+  moonshot: 'Kimi',
+  zai: 'GLM',
 };
 
 // ============================================================================

--- a/functions/src/apiKeys.ts
+++ b/functions/src/apiKeys.ts
@@ -48,7 +48,7 @@ function decrypt(encrypted: string, iv: string, tag: string, keyValue: string): 
 // Valid provider IDs (AI providers + tool providers like Brave Search)
 const VALID_PROVIDERS = [
   'claude', 'openai', 'google', 'perplexity', 'mistral',
-  'cohere', 'deepseek', 'grok',
+  'cohere', 'deepseek', 'grok', 'moonshot', 'zai',
   // Tool providers (for Analyze mode features)
   'brave',
   // Media providers (for Create mode)

--- a/functions/src/modelRegistry.ts
+++ b/functions/src/modelRegistry.ts
@@ -112,6 +112,8 @@ export const DEFAULT_PROVIDER_MODELS: Record<string, string> = {
   cohere: 'command-a-reasoning-08-2025',
   deepseek: 'deepseek-v4-flash',
   grok: 'grok-4.3',
+  moonshot: 'kimi-k3',
+  zai: 'glm-5.2',
 };
 
 const MODELS_REQUIRING_TEMPERATURE_1 = new Set([

--- a/functions/src/providers/openai/runtime.ts
+++ b/functions/src/providers/openai/runtime.ts
@@ -107,6 +107,16 @@ const OPENAI_COMPATIBLE_CONFIGS: Record<string, ProviderConfig> = {
     authHeader: 'Authorization',
     authPrefix: 'Bearer ',
   },
+  moonshot: {
+    baseUrl: 'https://api.moonshot.ai/v1/chat/completions',
+    authHeader: 'Authorization',
+    authPrefix: 'Bearer ',
+  },
+  zai: {
+    baseUrl: 'https://api.z.ai/api/paas/v4/chat/completions',
+    authHeader: 'Authorization',
+    authPrefix: 'Bearer ',
+  },
 };
 
 // ============================================================================
@@ -122,8 +132,9 @@ export class OpenAIRuntime implements ProviderRuntime {
     this.providerId = providerId;
     this.config = OPENAI_COMPATIBLE_CONFIGS[providerId] || OPENAI_COMPATIBLE_CONFIGS.openai;
 
-    // OpenAI, Mistral, and Grok (x.ai) support tools via OpenAI-compatible format
-    this.supportsTools = ['openai', 'mistral', 'grok'].includes(providerId);
+    // OpenAI, Mistral, Grok (x.ai), Kimi (Moonshot), and GLM (Z.ai) support tools
+    // via OpenAI-compatible format
+    this.supportsTools = ['openai', 'mistral', 'grok', 'moonshot', 'zai'].includes(providerId);
   }
 
   /**

--- a/functions/src/providers/registry.ts
+++ b/functions/src/providers/registry.ts
@@ -21,7 +21,9 @@ export type SupportedProvider =
   | 'mistral'
   | 'deepseek'
   | 'grok'
-  | 'cohere';
+  | 'cohere'
+  | 'moonshot'
+  | 'zai';
 
 /**
  * Check if a provider is supported by the V2 endpoint
@@ -35,6 +37,8 @@ export function isV2Supported(providerId: string): providerId is SupportedProvid
     'deepseek',
     'grok',
     'cohere',
+    'moonshot',
+    'zai',
   ].includes(providerId);
 }
 
@@ -74,6 +78,12 @@ export class ProviderRegistry {
       case 'grok':
         return getOpenAIRuntime('grok');
 
+      case 'moonshot':
+        return getOpenAIRuntime('moonshot');
+
+      case 'zai':
+        return getOpenAIRuntime('zai');
+
       default:
         throw new Error(`Provider '${providerId}' is not supported by V2 endpoint`);
     }
@@ -95,6 +105,6 @@ export class ProviderRegistry {
    * Get all supported provider IDs
    */
   static getSupportedProviders(): SupportedProvider[] {
-    return ['claude', 'openai', 'google', 'mistral', 'deepseek', 'grok', 'cohere'];
+    return ['claude', 'openai', 'google', 'mistral', 'deepseek', 'grok', 'cohere', 'moonshot', 'zai'];
   }
 }

--- a/functions/src/testApiKey.ts
+++ b/functions/src/testApiKey.ts
@@ -87,6 +87,29 @@ const PROBES: Record<string, ProviderProbe> = {
     }),
     treat400AsValid: true,
   },
+  moonshot: {
+    request: (key) => ({
+      url: 'https://api.moonshot.ai/v1/models',
+      init: { method: 'GET', headers: { Authorization: `Bearer ${key}` } },
+    }),
+  },
+  zai: {
+    // Z.ai's OpenAI-compatible surface has no reliable models-list endpoint;
+    // probe with a 1-token completion like Perplexity.
+    request: (key) => ({
+      url: 'https://api.z.ai/api/paas/v4/chat/completions',
+      init: {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'glm-5.2',
+          messages: [{ role: 'user', content: 'ping' }],
+          max_tokens: 1,
+        }),
+      },
+    }),
+    treat400AsValid: true,
+  },
   brave: {
     request: (key) => ({
       url: 'https://api.search.brave.com/res/v1/web/search?q=ping&count=1',

--- a/functions/test/providerRegistry.test.js
+++ b/functions/test/providerRegistry.test.js
@@ -23,6 +23,16 @@ describe('ProviderRegistry', () => {
       /not supported/
     );
   });
+
+  it('supports moonshot and zai as OpenAI-compatible V2 runtimes with tools', () => {
+    for (const providerId of ['moonshot', 'zai']) {
+      assert.equal(isV2Supported(providerId), true);
+      assert.equal(ProviderRegistry.getSupportedProviders().includes(providerId), true);
+      const runtime = ProviderRegistry.get(providerId);
+      assert.equal(runtime.providerId, providerId);
+      assert.equal(runtime.supportsTools, true);
+    }
+  });
 });
 
 describe('modelRegistry', () => {
@@ -33,6 +43,10 @@ describe('modelRegistry', () => {
     assert.equal(getDefaultModel('grok'), 'grok-4.3');
     assert.equal(resolveProviderModelId('grok', 'grok-build-latest'), 'grok-build-0.1');
     assert.equal(getDefaultModel('cohere'), 'command-a-reasoning-08-2025');
+    assert.equal(getDefaultModel('moonshot'), 'kimi-k3');
+    assert.equal(getDefaultModel('zai'), 'glm-5.2');
+    assert.equal(resolveProviderModelId('moonshot', ''), 'kimi-k3');
+    assert.equal(resolveProviderModelId('zai', ''), 'glm-5.2');
   });
 
   it('omits temperature for Claude 5-family models while preserving other model normalization', () => {


### PR DESCRIPTION
## Summary
- Wire `moonshot` (Kimi) and `zai` (GLM) as OpenAI-compatible providers across all three proxy endpoints: callable `proxyAIRequest`, V1 `proxyAIRequestStream`, and V2 `proxyAIRequestStreamV2` (registry + shared `OpenAIRuntime` configs).
- Tool calling enabled for both; vision gated to the Kimi K-series (`kimi-k*`) and the GLM vision line (`glm-5v*`).
- Key-slot allowlist (`VALID_PROVIDERS`), default models (`kimi-k3`, `glm-5.2`), display names, and test-connection probes (Moonshot via `GET /v1/models`; Z.ai via a 1-token completion probe since its OpenAI-compatible surface has no models-list endpoint).
- Live-routing workflow passes optional `MOONSHOT_API_KEY` / `ZAI_API_KEY` secrets (harness skips providers with absent keys).

Part 1 of the two-repo provider expansion; web-repo catalog/UI changes follow after this deploys. Spec: `symposium-ai-web/docs/provider-expansion-kimi-glm-meta.md`. Meta (Muse Spark) was deliberately dropped — its preview ToS prohibits BYOK.

## Test plan
- `npm run check:functions` green (build + 52 tests, including new registry/default-model assertions for both providers).
- Post-deploy: BYOK live smoke via the web app (save + test-connection, Chat/Compare/Debate per provider, vision attachment on kimi-k3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)