### PR TITLE
security: harden account deletion and export-job invocation

### DIFF
--- a/functions/src/cloudPayloadStorage.ts
+++ b/functions/src/cloudPayloadStorage.ts
@@ -309,6 +309,24 @@ async function deleteStoragePrefix(uid: string, prefix: string): Promise<{ bytes
   return { bytes, objects };
 }
 
+/**
+ * Delete EVERY Cloud Storage object under a user's prefix (`users/{uid}/`).
+ * Used by account deletion — broader than deleteStoragePrefix, which is scoped
+ * to a single session for the interactive callable path. Prefix-scoped to the
+ * user, so it cannot reach other users' data or content-addressed shared exports
+ * (which live under `exports/`, not `users/`).
+ */
+export async function deleteAllUserStorage(uid: string): Promise<{ objects: number }> {
+  if (!uid) throw new Error('deleteAllUserStorage: uid is required');
+  const [files] = await bucket().getFiles({ prefix: `users/${uid}/` });
+  let objects = 0;
+  for (const file of files) {
+    await file.delete({ ignoreNotFound: true });
+    objects += 1;
+  }
+  return { objects };
+}
+
 async function deleteCollection(collection: FirebaseFirestore.CollectionReference, batchSize = 400): Promise<number> {
   let deleted = 0;
   while (true) {

--- a/functions/src/deleteAccount.ts
+++ b/functions/src/deleteAccount.ts
@@ -1,5 +1,6 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import * as admin from 'firebase-admin';
+import { deleteAllUserStorage } from './cloudPayloadStorage';
 
 // Initialize Admin if not already
 try { admin.app(); } catch { admin.initializeApp(); }
@@ -16,24 +17,25 @@ export const deleteAccount = onCall(async (request) => {
     // NOTE: The /trialHistory/{uid} collection is intentionally NOT deleted here.
     // This prevents trial abuse where users delete their account and re-register
     // to get unlimited free trials. The trialHistory collection tracks email hashes
-    // and UIDs that have used trials, surviving account deletion.
+    // and UIDs that have used trials, surviving account deletion. It is a top-level
+    // collection, so the recursiveDelete below (scoped to users/{uid}) never touches it.
 
-    // Delete Firestore user data
-    const userDocRef = firestore.collection('users').doc(uid);
-
-    // Get and delete subcollections manually
-    const subCollections = await userDocRef.listCollections();
-    for (const subCollection of subCollections) {
-      const snapshot = await subCollection.get();
-      const batch = firestore.batch();
-      snapshot.forEach((doc) => {
-        batch.delete(doc.ref);
-      });
-      await batch.commit();
+    // Delete all Cloud Storage objects owned by the user (session payloads, exports,
+    // audio) before removing the Firestore records that reference them. Best-effort:
+    // a storage failure must not block account deletion, so log and continue rather
+    // than leaving the account un-deletable.
+    try {
+      const { objects } = await deleteAllUserStorage(uid);
+      console.log(`Account deletion: removed ${objects} storage object(s) for user ${uid}`);
+    } catch (storageError) {
+      console.error(`Account deletion: storage cleanup failed for user ${uid}`, storageError);
     }
 
-    // Delete the user document
-    await userDocRef.delete();
+    // Recursively delete the user document AND all nested subcollections
+    // (conversations/{id}/messages, conversations/{id}/artifacts, apiKeys, billing,
+    // usage, etc.). The previous one-level batch loop orphaned nested subcollections.
+    const userDocRef = firestore.collection('users').doc(uid);
+    await firestore.recursiveDelete(userDocRef);
 
     // Delete the Auth user
     try {

--- a/functions/src/exports/runExportJob.ts
+++ b/functions/src/exports/runExportJob.ts
@@ -17,6 +17,7 @@
 import { onRequest } from 'firebase-functions/v2/https';
 import { defineSecret } from 'firebase-functions/params';
 import { getFirestore } from 'firebase-admin/firestore';
+import { OAuth2Client } from 'google-auth-library';
 import { getExportBucket } from './utils';
 import type { Browser } from 'puppeteer-core';
 
@@ -53,6 +54,40 @@ import {
 } from './artifactBranding';
 
 const provenanceHmacKey = defineSecret('PROVENANCE_HMAC_KEY');
+
+// Verifies that a request carries a valid Cloud Tasks OIDC token. This endpoint
+// is invoked ONLY by the exports queue (see enqueueExportJob), which attaches an
+// OIDC token whose audience is this function's URL and whose identity is the
+// App Engine default service account. Rejecting anything else prevents arbitrary
+// callers from triggering or replaying export jobs.
+const oidcClient = new OAuth2Client();
+
+async function verifyCloudTasksInvoker(
+  authorizationHeader: string | undefined,
+): Promise<{ status: number; error: string } | null> {
+  const token = typeof authorizationHeader === 'string'
+    ? (authorizationHeader.match(/^Bearer (.+)$/)?.[1] ?? null)
+    : null;
+  if (!token) {
+    return { status: 401, error: 'Unauthorized: missing bearer token' };
+  }
+
+  const project = process.env.GCLOUD_PROJECT || process.env.GCP_PROJECT || '';
+  // Must mirror enqueueExportJob's oidcToken settings exactly.
+  const expectedAudience = `https://us-central1-${project}.cloudfunctions.net/runExportJob`;
+  const expectedEmail = `${project}@appspot.gserviceaccount.com`;
+
+  try {
+    const ticket = await oidcClient.verifyIdToken({ idToken: token, audience: expectedAudience });
+    const payload = ticket.getPayload();
+    if (!payload || payload.email !== expectedEmail || payload.email_verified !== true) {
+      return { status: 403, error: 'Forbidden: unexpected invoker identity' };
+    }
+    return null;
+  } catch {
+    return { status: 401, error: 'Unauthorized: invalid token' };
+  }
+}
 
 // Puppeteer version for provenance
 let puppeteerVersion = 'unknown';
@@ -174,6 +209,14 @@ export const runExportJob = onRequest(
   async (req, res) => {
     if (req.method !== 'POST') {
       res.status(405).send('Method not allowed');
+      return;
+    }
+
+    // Authenticate the caller as the Cloud Tasks exports queue before doing any work.
+    const authError = await verifyCloudTasksInvoker(req.headers.authorization);
+    if (authError) {
+      console.warn(`[runExportJob] Rejected unauthenticated invocation: ${authError.error}`);
+      res.status(authError.status).json({ error: authError.error });
       return;
     }
 


### PR DESCRIPTION
Two pre-meeting security fixes surfaced by the architecture/security review.

## Changes

**Account deletion (\`deleteAccount.ts\`)**
- Use \`recursiveDelete\` on the user doc so nested conversation subcollections (\`messages\`, \`artifacts\`) are no longer orphaned — the previous one-level batch loop left them behind.
- Delete the user's Cloud Storage objects (\`users/{uid}/\`) via new exported \`deleteAllUserStorage\` in \`cloudPayloadStorage.ts\`. Best-effort: a storage failure logs and continues so it can't block account deletion.
- Closes the GDPR/erasure gap where Storage payloads and nested docs survived deletion.

**Export-job invocation (\`runExportJob.ts\`)**
- Verify the Cloud Tasks OIDC token (audience + App Engine service-account identity, reconstructed to mirror \`enqueueExportJob\` exactly) before processing. Previously the HTTP endpoint trusted any POSTed \`jobId\`, relying solely on Cloud Run IAM.

## Verification
- \`npm --prefix functions run build\` / \`tsc --noEmit\`: clean.

## ⚠️ Requires live verification before/after deploy
Merging deploys functions to production. CI validates the build+tests but NOT these two runtime behaviors:
1. **PDF/report export still succeeds end-to-end** — confirms the OIDC audience string matches what Cloud Tasks actually sends. If it mismatches, all exports 401/403.
2. **Account deletion removes the full Firestore subtree + Storage prefix.**

Have a revert ready if export breaks post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)