### PR TITLE
Fix: GPT-5.6 + function tools 400s on chat completions — set reasoning_effort 'none'

### DIFF
--- a/functions/src/modelRegistry.ts
+++ b/functions/src/modelRegistry.ts
@@ -150,6 +150,23 @@ const MODELS_UNSUPPORTED_CHAT_COMPLETIONS = new Set([
   'gpt-5.5-pro',
 ]);
 
+// GPT-5.6 GA on /v1/chat/completions cannot combine function tools with its
+// default reasoning: "Function tools with reasoning_effort are not supported
+// for gpt-5.6-sol in /v1/chat/completions. To use function tools, use
+// /v1/responses or set reasoning_effort to 'none'." (live-verified
+// 2026-07-24; with effort 'none' all three models emit correct tool calls).
+// Proper long-term fix is a Responses API migration.
+const MODELS_REQUIRING_REASONING_EFFORT_NONE_FOR_TOOLS = new Set([
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
+]);
+
+export function requiresReasoningEffortNoneForTools(modelId: string | undefined): boolean {
+  if (!modelId) return false;
+  return MODELS_REQUIRING_REASONING_EFFORT_NONE_FOR_TOOLS.has(resolveModelAlias(modelId));
+}
+
 export function resolveModelAlias(modelId: string): string {
   return MODEL_ALIASES[modelId] || modelId;
 }

--- a/functions/src/providers/openai/runtime.ts
+++ b/functions/src/providers/openai/runtime.ts
@@ -18,7 +18,7 @@ import type {
   CanonicalToolDefinition,
   CanonicalToolChoice,
 } from '../../types/canonical';
-import { normalizeProviderTemperature } from '../../modelRegistry';
+import { normalizeProviderTemperature, requiresReasoningEffortNoneForTools } from '../../modelRegistry';
 import type { ProviderRuntime, ProviderRequest, BuiltRequest, ProviderConfig } from '../types';
 import {
   parseSSEStream,
@@ -170,6 +170,11 @@ export class OpenAIRuntime implements ProviderRuntime {
       body.tools = transformToolsForOpenAI(request.tools);
       if (request.toolChoice) {
         body.tool_choice = transformToolChoiceForOpenAI(request.toolChoice);
+      }
+      // GPT-5.6 rejects function tools + reasoning on chat completions;
+      // OpenAI's own error text prescribes reasoning_effort 'none'.
+      if (this.providerId === 'openai' && requiresReasoningEffortNoneForTools(request.model)) {
+        body.reasoning_effort = 'none';
       }
     }
 


### PR DESCRIPTION
## The second 5.6 restriction

PR #139 fixed temperature and un-broke plain chat, but every **tool-using** request (Analyze) still 400'd. Raw error from api.openai.com, reproduced with the app's exact 10-tool payload:

> Function tools with reasoning_effort are not supported for gpt-5.6-sol in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.

That's categorical (every tool individually triggers it), which is why chat (no tools) worked and Analyze (any tools) failed.

## Fix

When the model is in the new `MODELS_REQUIRING_REASONING_EFFORT_NONE_FOR_TOOLS` set (5.6 Sol/Terra/Luna) and tools are attached, the OpenAI runtime sets `reasoning_effort: 'none'` — the remedy OpenAI's own error text prescribes. Scoped so no working request changes. Live-verified: all three models emit correct tool calls with the full Analyze toolset. Long-term: Responses API migration (tracked in code comment; `MODELS_UNSUPPORTED_CHAT_COMPLETIONS` precedent).

Functions tests 52/52, build clean. Merging auto-deploys; I'll live-verify the deployed proxy with the full toolset afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)