### PR TITLE
fix(salesforce-docs): working live fallback, BM25 ranking, index cache, server tests

### DIFF
--- a/functions/scripts/salesforce-docs-index.mjs
+++ b/functions/scripts/salesforce-docs-index.mjs
@@ -189,9 +189,17 @@ function summarizeIndex(index) {
   };
 }
 
-function uploadWithGcloud(outputPath, storagePath) {
+async function uploadWithGcloud(index, outputPath, storagePath) {
+  // The local file stays pretty-printed for inspection; the stored object must
+  // be minified because lookup paths download and parse it.
+  const minifiedPath = `${outputPath.replace(/\.json$/, '')}.upload.json`;
+  await fs.writeFile(minifiedPath, JSON.stringify(index), 'utf-8');
   const destination = `gs://${SALESFORCE_DOC_INDEX_BUCKET}/${storagePath}`;
-  execFileSync('gcloud', ['storage', 'cp', outputPath, destination], { stdio: 'inherit' });
+  try {
+    execFileSync('gcloud', ['storage', 'cp', minifiedPath, destination], { stdio: 'inherit' });
+  } finally {
+    await fs.rm(minifiedPath, { force: true });
+  }
 }
 
 async function main() {
@@ -256,7 +264,7 @@ async function main() {
   if (options.upload) {
     console.log('[salesforce-docs-index] Uploading index to Firebase Storage...');
     if (options.uploadMode === 'gcloud') {
-      uploadWithGcloud(options.out, index.sourcePolicy.storagePath);
+      await uploadWithGcloud(index, options.out, index.sourcePolicy.storagePath);
     } else {
       await writeSalesforceDocsIndex(index);
     }

--- a/functions/src/salesforceDocsIndex.ts
+++ b/functions/src/salesforceDocsIndex.ts
@@ -64,7 +64,7 @@ interface SalesforceDocsSitemapEntry {
   sourceLabel: string;
 }
 
-interface OfficialDocContent {
+export interface OfficialDocContent {
   text: string;
   contentQuality: SalesforceDocsContentQuality;
   title?: string;
@@ -1143,24 +1143,60 @@ export async function writeSalesforceDocsIndex(index: SalesforceDocsIndex): Prom
     headers: {
       'Content-Type': 'application/json; charset=utf-8',
     },
-    body: JSON.stringify(index, null, 2),
+    // Minified on purpose: the index is multi-MB and read on lookup paths.
+    body: JSON.stringify(index),
   });
 
   if (!response.ok) {
     const errorText = await response.text();
     throw new Error(`Failed to write Salesforce docs index to Cloud Storage (${response.status}): ${errorText}`);
   }
+  cachedIndexState = null;
 }
 
-async function readSalesforceDocsIndexText(): Promise<string | null> {
-  const downloadUrl = `https://storage.googleapis.com/storage/v1/b/${storageBucketPath()}/o/${storageObjectPath()}?alt=media`;
-  const response = await authorizedStorageFetch(downloadUrl, { method: 'GET' });
+const SALESFORCE_DOC_INDEX_CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface DownloadedSalesforceDocsIndex {
+  index: SalesforceDocsIndex | null;
+  generation?: string;
+}
+
+let cachedIndexState: {
+  promise: Promise<DownloadedSalesforceDocsIndex>;
+  validatedAtMs: number;
+} | null = null;
+
+async function fetchSalesforceDocsIndexGeneration(): Promise<string | null> {
+  const metadataUrl = `https://storage.googleapis.com/storage/v1/b/${storageBucketPath()}/o/${storageObjectPath()}?fields=generation`;
+  const response = await authorizedStorageFetch(metadataUrl, { method: 'GET' });
   if (response.status === 404) return null;
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Failed to read Salesforce docs index from Cloud Storage (${response.status}): ${errorText}`);
+    throw new Error(`Failed to read Salesforce docs index metadata (${response.status}): ${errorText}`);
   }
-  return response.text();
+  const metadata = await response.json() as { generation?: string };
+  return metadata.generation || null;
+}
+
+async function downloadSalesforceDocsIndex(): Promise<DownloadedSalesforceDocsIndex> {
+  try {
+    const downloadUrl = `https://storage.googleapis.com/storage/v1/b/${storageBucketPath()}/o/${storageObjectPath()}?alt=media`;
+    const response = await authorizedStorageFetch(downloadUrl, { method: 'GET' });
+    if (response.status === 404) return { index: null };
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to read Salesforce docs index from Cloud Storage (${response.status}): ${errorText}`);
+    }
+    const generation = response.headers.get('x-goog-generation') || undefined;
+    const parsed = JSON.parse(await response.text()) as SalesforceDocsIndex;
+    return {
+      index: parsed && parsed.version === SALESFORCE_DOC_INDEX_VERSION ? parsed : null,
+      generation,
+    };
+  } catch (error) {
+    console.warn('[salesforceDocsIndex] Failed to read Salesforce docs index:', error);
+    return { index: null };
+  }
 }
 
 function isOfficialSalesforceUrl(urlValue: string): boolean {
@@ -1172,13 +1208,15 @@ function isOfficialSalesforceUrl(urlValue: string): boolean {
   }
 }
 
-function canonicalizeUrl(urlValue: string): string | null {
+export function canonicalizeUrl(urlValue: string): string | null {
   try {
     const url = new URL(urlValue);
     if (!isOfficialSalesforceUrl(url.toString())) return null;
     url.hash = '';
     for (const key of Array.from(url.searchParams.keys())) {
-      if (/^(utm_|cmpid|d|nc|trk|mc_)/i.test(key)) {
+      // Prefix-match only true tracking-param families; `d`, `nc`, `cmpid` must be
+      // exact — a prefix match would strip real params like `docId`/`deliverable`.
+      if (/^(?:utm_|trk|mc_)/i.test(key) || /^(?:d|nc|cmpid)$/i.test(key)) {
         url.searchParams.delete(key);
       }
     }
@@ -1619,8 +1657,20 @@ function inferSourceType(urlValue: string): SalesforceDocsIndexRecord['sourceTyp
   return 'official_doc';
 }
 
-function inferStatus(text: string): SalesforceDocsIndexRecord['status'] {
-  const normalized = text.replace(/\s+/g, ' ');
+/**
+ * Standard forward-looking-statements / safe-harbor boilerplate appears on GA
+ * release-notes and docs pages; it must not flag the whole document as preview.
+ * Sentences carrying that boilerplate are dropped before status matching.
+ */
+function stripSalesforceSafeHarborText(text: string): string {
+  return text
+    .split(/(?<=[.!?])\s+/)
+    .filter((sentence) => !/forward-looking statements?|unreleased services or features|purchase decisions?.{0,120}(?:currently|generally) available/i.test(sentence))
+    .join(' ');
+}
+
+export function inferSalesforceDocumentationStatus(text: string): SalesforceDocsIndexRecord['status'] {
+  const normalized = stripSalesforceSafeHarborText(text.replace(/\s+/g, ' '));
   if (
     /\b(?:developer|public|private)\s+preview\b/i.test(normalized)
     || /\b(?:this|the)\s+(?:release|feature|document|content|functionality|release note)\s+is\s+(?:currently\s+)?(?:in\s+)?(?:preview|beta|pilot)\b/i.test(normalized)
@@ -1697,12 +1747,12 @@ async function fetchTextWithCurl(url: string, timeoutMs: number): Promise<string
   return result.stdout;
 }
 
-async function fetchText(url: string, timeoutMs = 20000): Promise<string> {
+async function fetchText(url: string, timeoutMs = 20000, maxAttempts = 3): Promise<string> {
   if (!isOfficialSalesforceUrl(url)) {
     throw new Error(`URL is not an allowed official Salesforce URL: ${url}`);
   }
   let lastError: Error | null = null;
-  for (let attempt = 0; attempt < 3; attempt += 1) {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
@@ -1718,13 +1768,13 @@ async function fetchText(url: string, timeoutMs = 20000): Promise<string> {
       }
       lastError = new Error(`HTTP ${response.status}`);
       if (ALLOW_CURL_TEXT_FETCH && response.status === 403) break;
-      if (![403, 429, 500, 502, 503, 504].includes(response.status) || attempt === 2) {
+      if (![403, 429, 500, 502, 503, 504].includes(response.status) || attempt === maxAttempts - 1) {
         break;
       }
     } catch (error: any) {
       lastError = error instanceof Error ? new Error(fetchErrorMessage(error)) : new Error(fetchErrorMessage(error, 'Unknown fetch failure'));
       if (ALLOW_CURL_TEXT_FETCH && /UNABLE_TO_VERIFY|fetch failed/i.test(lastError.message)) break;
-      if (attempt === 2) break;
+      if (attempt === maxAttempts - 1) break;
     } finally {
       clearTimeout(timeout);
     }
@@ -1838,8 +1888,8 @@ async function fetchPdfDocument(url: string, timeoutMs = 60000): Promise<Fetched
   throw lastError || new Error('Unknown PDF fetch failure');
 }
 
-async function fetchOfficialJson<T>(url: string): Promise<T> {
-  const text = await fetchText(url);
+async function fetchOfficialJson<T>(url: string, options: { timeoutMs?: number; maxAttempts?: number } = {}): Promise<T> {
+  const text = await fetchText(url, options.timeoutMs ?? 20000, options.maxAttempts ?? 3);
   return JSON.parse(text) as T;
 }
 
@@ -1949,7 +1999,10 @@ function parseDeveloperDocsReference(urlValue: string): { docId: string; deliver
   }
 }
 
-async function fetchDeveloperDocsContent(urlValue: string): Promise<OfficialDocContent | null> {
+async function fetchDeveloperDocsContent(
+  urlValue: string,
+  options: { timeoutMs?: number; maxAttempts?: number } = {},
+): Promise<OfficialDocContent | null> {
   const reference = parseDeveloperDocsReference(urlValue);
   if (!reference) return null;
 
@@ -1972,7 +2025,7 @@ async function fetchDeveloperDocsContent(urlValue: string): Promise<OfficialDocC
   };
 
   const documentUrl = `https://developer.salesforce.com/docs/get_document/${encodeURIComponent(reference.docId)}`;
-  const document = await fetchOfficialJson<DeveloperDocumentResponse>(documentUrl);
+  const document = await fetchOfficialJson<DeveloperDocumentResponse>(documentUrl, options);
   const documentVersion = document.version?.doc_version;
   const releaseLabel = document.version?.version_text;
   const apiVersion = document.version?.release_version;
@@ -1994,7 +2047,7 @@ async function fetchDeveloperDocsContent(urlValue: string): Promise<OfficialDocC
       'en-us',
       encodeURIComponent(documentVersion),
     ].join('/');
-    const content = await fetchOfficialJson<DeveloperContentResponse>(contentUrl);
+    const content = await fetchOfficialJson<DeveloperContentResponse>(contentUrl, options);
     html = content.content;
     title = content.title || title;
   }
@@ -2017,22 +2070,66 @@ async function fetchDeveloperDocsContent(urlValue: string): Promise<OfficialDocC
   };
 }
 
-async function fetchOfficialDoc(url: string): Promise<OfficialDocContent> {
-  let developerDocsApiError: string | undefined;
+function isHelpArticleViewMetadataUrl(urlValue: string): boolean {
   try {
-    const developerContent = await fetchDeveloperDocsContent(url);
-    if (developerContent) return developerContent;
-  } catch (error: any) {
-    developerDocsApiError = error?.message || 'Unknown developer docs API failure';
+    const url = new URL(urlValue);
+    return url.hostname === 'help.salesforce.com'
+      && url.pathname.includes('/articleView')
+      && Boolean(url.searchParams.get('id'));
+  } catch {
+    return false;
+  }
+}
+
+export type OfficialDocRetrievalPlan = 'developer_api' | 'rendered_help' | 'help_metadata' | 'raw_html';
+
+export interface FetchOfficialDocOptions {
+  /** Headless-Chrome rendering of help.salesforce.com release-notes articles. Index build only — never enable inside executeTool. */
+  allowRendering?: boolean;
+  fetchTimeoutMs?: number;
+  maxAttempts?: number;
+}
+
+export function officialDocRetrievalPlan(
+  urlValue: string,
+  options: { allowRendering?: boolean } = {},
+): OfficialDocRetrievalPlan {
+  const allowRendering = options.allowRendering !== false;
+  if (parseDeveloperDocsReference(urlValue)) return 'developer_api';
+  if (allowRendering && isRenderableSalesforceHelpArticleUrl(urlValue)) return 'rendered_help';
+  if (isHelpArticleViewMetadataUrl(urlValue)) return 'help_metadata';
+  return 'raw_html';
+}
+
+export async function fetchOfficialDocContent(
+  url: string,
+  options: FetchOfficialDocOptions = {},
+): Promise<OfficialDocContent> {
+  const plan = officialDocRetrievalPlan(url, options);
+  const timeoutMs = options.fetchTimeoutMs ?? 20000;
+  const maxAttempts = options.maxAttempts ?? 3;
+  let developerDocsApiError: string | undefined;
+
+  if (plan === 'developer_api') {
+    try {
+      const developerContent = await fetchDeveloperDocsContent(url, { timeoutMs, maxAttempts });
+      if (developerContent) return developerContent;
+    } catch (error: any) {
+      developerDocsApiError = error?.message || 'Unknown developer docs API failure';
+    }
   }
 
-  const renderedHelpArticle = await fetchRenderedHelpArticleContent(url);
-  if (renderedHelpArticle) return renderedHelpArticle;
+  if (plan === 'rendered_help') {
+    const renderedHelpArticle = await fetchRenderedHelpArticleContent(url);
+    if (renderedHelpArticle) return renderedHelpArticle;
+  }
 
-  const helpArticleMetadata = buildHelpArticleMetadata(url);
-  if (helpArticleMetadata) return helpArticleMetadata;
+  if (plan === 'rendered_help' || plan === 'help_metadata') {
+    const helpArticleMetadata = buildHelpArticleMetadata(url);
+    if (helpArticleMetadata) return helpArticleMetadata;
+  }
 
-  const html = await fetchText(url);
+  const html = await fetchText(url, timeoutMs, maxAttempts);
   const normalized = stripHtmlTags(html);
   if (normalized.length < 80) {
     throw new Error(`Fetched content was too short (${normalized.length} chars)`);
@@ -2210,13 +2307,13 @@ async function buildRecord(
   if (!url) {
     throw new Error(`URL is not an allowed official Salesforce URL: ${rawUrl}`);
   }
-  const content = await fetchOfficialDoc(url);
+  const content = await fetchOfficialDocContent(url);
   const text = content.text;
   const recordId = `sf-doc-index-${index}`;
   const textChunks = content.contentQuality === 'full_text'
     ? buildTextChunks(text, recordId)
     : [];
-  const status = inferStatus(`${text} ${content.releaseLabel || ''}`);
+  const status = inferSalesforceDocumentationStatus(`${text} ${content.releaseLabel || ''}`);
   const warnings = [...sourceWarnings(`${text} ${content.releaseLabel || ''}`, status), ...(content.warnings || [])];
   return {
     id: recordId,
@@ -2275,7 +2372,7 @@ async function buildPdfRecord(
     ...topics.flatMap((topic) => topic.keywords),
   ]));
   const version = inferPdfVersion(extracted.text);
-  const status = inferStatus(version.releaseLabel || source.title);
+  const status = inferSalesforceDocumentationStatus(version.releaseLabel || source.title);
   const refreshCadenceDays = source.refreshCadenceDays || PDF_REFRESH_CADENCE_DAYS;
   const recordSeed = {
     etag: pdf.etag,
@@ -2583,7 +2680,7 @@ function countFailuresByDomain(index: SalesforceDocsIndex): Record<string, numbe
   }, {} as Record<string, number>);
 }
 
-function refreshCoverageError(index: SalesforceDocsIndex): string | null {
+export function refreshCoverageError(index: SalesforceDocsIndex): string | null {
   const developerRecords = developerDocRecordCount(index);
   if (developerRecords < MIN_REFRESH_DEVELOPER_DOC_RECORDS) {
     return [
@@ -2629,16 +2726,41 @@ export async function refreshSalesforceDocsIndexNow(): Promise<SalesforceDocsInd
   return index;
 }
 
+/**
+ * Cached index reader. The parsed index is multi-MB, so instances hold one
+ * shared copy: the in-flight promise is cached (thundering-herd guard at cold
+ * start), a fresh copy is served inside the TTL, and after the TTL the stored
+ * object generation is revalidated so a re-download only happens on change.
+ */
 export async function readSalesforceDocsIndex(): Promise<SalesforceDocsIndex | null> {
-  try {
-    const indexText = await readSalesforceDocsIndexText();
-    if (!indexText) return null;
-    const parsed = JSON.parse(indexText) as SalesforceDocsIndex;
-    return parsed && parsed.version === SALESFORCE_DOC_INDEX_VERSION ? parsed : null;
-  } catch (error) {
-    console.warn('[salesforceDocsIndex] Failed to read Salesforce docs index:', error);
-    return null;
+  const now = Date.now();
+  if (cachedIndexState) {
+    if (now - cachedIndexState.validatedAtMs < SALESFORCE_DOC_INDEX_CACHE_TTL_MS) {
+      return (await cachedIndexState.promise).index;
+    }
+    const settled = await cachedIndexState.promise;
+    if (settled.index && settled.generation) {
+      try {
+        const generation = await fetchSalesforceDocsIndexGeneration();
+        if (generation && generation === settled.generation) {
+          cachedIndexState.validatedAtMs = now;
+          return settled.index;
+        }
+      } catch (error) {
+        console.warn('[salesforceDocsIndex] Salesforce docs index revalidation failed; serving cached copy:', error);
+        cachedIndexState.validatedAtMs = now;
+        return settled.index;
+      }
+    }
   }
+
+  const state = { promise: downloadSalesforceDocsIndex(), validatedAtMs: now };
+  cachedIndexState = state;
+  const result = await state.promise;
+  if (!result.index && cachedIndexState === state) {
+    cachedIndexState = null;
+  }
+  return result.index;
 }
 
 function tokensForTopic(topic: SalesforceDocsLookupTopicLike): string[] {
@@ -2662,33 +2784,146 @@ function tokensForTopic(topic: SalesforceDocsLookupTopicLike): string[] {
   ].join(' ').toLowerCase().split(/[^a-z0-9]+/).filter((token) => token.length >= 3)));
 }
 
-function scoreTextForTokens(text: string, tokens: string[]): number {
-  const haystack = text.toLowerCase();
+// --- BM25 chunk relevance over the cached index -----------------------------
+// Corpus stats (N, avgdl) are one cheap pass per parsed index; document
+// frequency is computed lazily per token and memoized for the index object's
+// lifetime, so the first lookup pays the scan and later lookups reuse it.
+
+const BM25_K1 = 1.2;
+const BM25_B = 0.75;
+// Chunk influence on record scores is capped at 80 so topic-alias routing
+// (see scoreRecordForTopic) is not swamped by one hot chunk.
+const BM25_DISPLAY_SCALE = 8;
+const BM25_DISPLAY_CAP = 80;
+
+export interface SalesforceDocsBm25CorpusStats {
+  totalChunks: number;
+  avgChunkLength: number;
+  dfByToken: Map<string, number>;
+}
+
+const bm25StatsByIndex = new WeakMap<SalesforceDocsIndex, SalesforceDocsBm25CorpusStats>();
+const loweredChunkTextCache = new WeakMap<SalesforceDocsIndexTextChunk, string>();
+
+function loweredChunkText(chunk: SalesforceDocsIndexTextChunk): string {
+  let lowered = loweredChunkTextCache.get(chunk);
+  if (lowered === undefined) {
+    lowered = chunk.text.toLowerCase();
+    loweredChunkTextCache.set(chunk, lowered);
+  }
+  return lowered;
+}
+
+export function buildBm25CorpusStats(index: SalesforceDocsIndex): SalesforceDocsBm25CorpusStats {
+  let totalChunks = 0;
+  let totalLength = 0;
+  for (const record of index.records) {
+    for (const chunk of record.textChunks || []) {
+      totalChunks += 1;
+      totalLength += chunk.contentLength || chunk.text.length;
+    }
+  }
+  return {
+    totalChunks,
+    avgChunkLength: totalChunks > 0 ? totalLength / totalChunks : 0,
+    dfByToken: new Map(),
+  };
+}
+
+function getBm25CorpusStats(index: SalesforceDocsIndex): SalesforceDocsBm25CorpusStats {
+  const cached = bm25StatsByIndex.get(index);
+  if (cached) return cached;
+  const stats = buildBm25CorpusStats(index);
+  bm25StatsByIndex.set(index, stats);
+  return stats;
+}
+
+function documentFrequencyForToken(
+  index: SalesforceDocsIndex,
+  stats: SalesforceDocsBm25CorpusStats,
+  token: string,
+): number {
+  const cached = stats.dfByToken.get(token);
+  if (cached !== undefined) return cached;
+  let df = 0;
+  for (const record of index.records) {
+    for (const chunk of record.textChunks || []) {
+      if (loweredChunkText(chunk).includes(token)) df += 1;
+    }
+  }
+  stats.dfByToken.set(token, df);
+  return df;
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) return 0;
+  let count = 0;
+  let position = haystack.indexOf(needle);
+  while (position !== -1) {
+    count += 1;
+    position = haystack.indexOf(needle, position + needle.length);
+  }
+  return count;
+}
+
+export function bm25ChunkScore(
+  loweredText: string,
+  chunkLength: number,
+  tokens: string[],
+  stats: SalesforceDocsBm25CorpusStats,
+  dfResolver: (token: string) => number,
+): number {
+  if (stats.totalChunks === 0 || stats.avgChunkLength === 0) return 0;
   let score = 0;
   for (const token of tokens) {
-    if (!haystack.includes(token)) continue;
-    score += token.length >= 8 ? 4 : 2;
+    const tf = countOccurrences(loweredText, token);
+    if (tf === 0) continue;
+    const df = dfResolver(token);
+    const idf = Math.log(1 + (stats.totalChunks - df + 0.5) / (df + 0.5));
+    const lengthNorm = 1 - BM25_B + BM25_B * (chunkLength / stats.avgChunkLength);
+    score += idf * ((tf * (BM25_K1 + 1)) / (tf + BM25_K1 * lengthNorm));
   }
   return score;
+}
+
+type ChunkScorer = (chunk: SalesforceDocsIndexTextChunk, tokens: string[]) => number;
+
+function createChunkScorer(index: SalesforceDocsIndex): ChunkScorer {
+  const stats = getBm25CorpusStats(index);
+  const dfResolver = (token: string) => documentFrequencyForToken(index, stats, token);
+  return (chunk, tokens) => bm25ChunkScore(
+    loweredChunkText(chunk),
+    chunk.contentLength || chunk.text.length,
+    tokens,
+    stats,
+    dfResolver,
+  );
+}
+
+function scaleBm25ForDisplay(rawScore: number): number {
+  if (rawScore <= 0) return 0;
+  return Math.max(1, Math.min(Math.round(rawScore * BM25_DISPLAY_SCALE), BM25_DISPLAY_CAP));
 }
 
 function matchedChunksForRecord(
   record: SalesforceDocsIndexRecord,
   tokens: string[],
+  scoreChunk: ChunkScorer,
   maxChunks = MAX_MATCHED_CHUNKS_PER_SOURCE,
 ): NonNullable<SalesforceDocsIndexEvidenceSource['matchedChunks']> {
   if (!record.textChunks || record.textChunks.length === 0) return [];
   return record.textChunks
-    .map((chunk) => ({
+    .map((chunk) => ({ chunk, rawScore: scoreChunk(chunk, tokens) }))
+    .filter(({ rawScore }) => rawScore > 0)
+    .sort((a, b) => b.rawScore - a.rawScore || a.chunk.ordinal - b.chunk.ordinal)
+    .slice(0, maxChunks)
+    .map(({ chunk, rawScore }) => ({
       id: chunk.id,
       ordinal: chunk.ordinal,
       text: chunk.text,
-      score: scoreTextForTokens(chunk.text, tokens),
+      score: scaleBm25ForDisplay(rawScore),
       contentLength: chunk.contentLength,
-    }))
-    .filter((chunk) => chunk.score > 0)
-    .sort((a, b) => b.score - a.score || a.ordinal - b.ordinal)
-    .slice(0, maxChunks);
+    }));
 }
 
 function scoreRecordForTopic(
@@ -2696,11 +2931,14 @@ function scoreRecordForTopic(
   topic: SalesforceDocsLookupTopicLike,
   tokens: string[],
   aliasTopicIds: string[],
+  scoreChunk: ChunkScorer,
 ): number {
   if (isNonEnglishLocalizedSalesforceUrl(record.url)) return 0;
   let score = 0;
   const aliasTopicMatch = record.topicIds.some((topicId) => aliasTopicIds.includes(topicId));
-  if (aliasTopicMatch) score += 100;
+  // Alias routing is a strong prior, not a trump card: BM25 chunk relevance
+  // (capped at 80) must be able to outrank an alias match with weak content.
+  if (aliasTopicMatch) score += 40;
   const haystack = [
     record.title,
     record.url,
@@ -2712,10 +2950,10 @@ function scoreRecordForTopic(
     if (haystack.includes(token)) score += 2;
   }
   const chunkScores = record.textChunks
-    ? record.textChunks.map((chunk) => scoreTextForTokens(chunk.text, tokens))
+    ? record.textChunks.map((chunk) => scoreChunk(chunk, tokens))
     : [];
   const bestChunkScore = chunkScores.length > 0 ? Math.max(...chunkScores) : 0;
-  score += Math.min(bestChunkScore, 80);
+  score += scaleBm25ForDisplay(bestChunkScore);
   for (const riskSignalId of topic.riskSignalIds || []) {
     if (riskSignalId.includes('apex') && record.topicIds.some((id) => id.startsWith('apex-'))) score += 8;
     if (riskSignalId.includes('flow') && record.topicIds.some((id) => id.startsWith('flow-'))) score += 8;
@@ -2724,7 +2962,7 @@ function scoreRecordForTopic(
   }
   const scoringCategory = scoringCategoryForTopic(topic, aliasTopicIds);
   if (aliasTopicMatch && record.sourceType === 'developer_doc') {
-    score += 30;
+    score += 15;
   }
   if (aliasTopicMatch && record.sourceFormat === 'pdf' && record.topicIds.length > 5 && aliasTopicIds.length > 2) {
     score -= 20;
@@ -2814,11 +3052,12 @@ export async function lookupSalesforceDocsIndex(
   const topicSourceCounts = new Map<string, number>();
   const seenSourceKeys = new Set<string>();
 
+  const scoreChunk = createChunkScorer(index);
   for (const topic of topics) {
     const tokens = tokensForTopic(topic);
     const aliasTopicIds = aliasTopicIdsFor(topic);
     const scored = index.records
-      .map((record) => ({ record, score: scoreRecordForTopic(record, topic, tokens, aliasTopicIds) }))
+      .map((record) => ({ record, score: scoreRecordForTopic(record, topic, tokens, aliasTopicIds, scoreChunk) }))
       .filter((item) => item.score > 0)
       .sort((a, b) => b.score - a.score || a.record.title.localeCompare(b.record.title));
     const selected = selectScoredRecordsForTopic(scored, aliasTopicIds, options.maxResultsPerTopic);
@@ -2836,7 +3075,7 @@ export async function lookupSalesforceDocsIndex(
       const recordPdfRefreshStatus = item.record.sourceFormat === 'pdf'
         ? pdfRefreshStatus(item.record)
         : null;
-      const matchedChunks = matchedChunksForRecord(item.record, tokens);
+      const matchedChunks = matchedChunksForRecord(item.record, tokens, scoreChunk);
       const sourceWarnings = [
         ...item.record.warnings,
         `Source came from cached official Salesforce docs index generated ${index.generatedAt}.`,

--- a/functions/src/tools.ts
+++ b/functions/src/tools.ts
@@ -4,7 +4,7 @@ import { promises as dns } from 'dns';
 import * as net from 'net';
 import { getDecryptedApiKey, encryptionKey } from './apiKeys';
 import { executeWebSearch } from './web_search';
-import { lookupSalesforceDocsIndex } from './salesforceDocsIndex';
+import { fetchOfficialDocContent, inferSalesforceDocumentationStatus, lookupSalesforceDocsIndex } from './salesforceDocsIndex';
 import {
   getDecryptedDataServiceKey,
   CONNECTOR_AUTH_CONFIG,
@@ -330,6 +330,9 @@ interface SalesforceDocEvidenceSource {
   }>;
   searchSnippet?: string;
   warnings: string[];
+  apiVersion?: string;
+  releaseLabel?: string;
+  documentationVersion?: string;
   confidenceImpact: 'supports' | 'unclear' | 'preview-risk' | 'release-link-risk' | 'stale-risk';
 }
 
@@ -1127,6 +1130,155 @@ function stripHtmlTags(html: string): string {
 // salesforce_docs_lookup Handler
 // ============================================================================
 
+const SALESFORCE_DOCS_FALLBACK_CONCURRENCY = 3;
+const SALESFORCE_DOCS_FALLBACK_DEADLINE_MS = 70_000;
+const SALESFORCE_DOCS_QUERY_FETCH_OPTIONS = {
+  // Never launch headless Chrome inside executeTool; a single short attempt so
+  // one slow official host cannot consume the whole topic budget.
+  allowRendering: false,
+  fetchTimeoutMs: 10000,
+  maxAttempts: 1,
+} as const;
+
+interface SalesforceDocsFallbackCandidate {
+  title: string;
+  url: string;
+  snippet?: string;
+  content: string;
+  contentQuality: 'full_text' | 'metadata_only';
+  apiVersion?: string;
+  releaseLabel?: string;
+  documentationVersion?: string;
+  warnings: string[];
+}
+
+interface SalesforceDocsFallbackResolution {
+  topic: SalesforceDocsTopic;
+  candidates: SalesforceDocsFallbackCandidate[];
+  warnings: string[];
+  rejectedUrls: string[];
+}
+
+async function runWithConcurrency<T>(tasks: Array<() => Promise<T>>, limit: number): Promise<T[]> {
+  const results = new Array<T>(tasks.length);
+  let nextIndex = 0;
+  const workers = Array.from({ length: Math.max(1, Math.min(limit, tasks.length)) }, async () => {
+    while (nextIndex < tasks.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await tasks[index]();
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+async function fetchSalesforceDocsFallbackCandidate(
+  topic: SalesforceDocsTopic,
+  candidate: { title: string; url: string; snippet?: string },
+  warnings: string[],
+): Promise<SalesforceDocsFallbackCandidate | null> {
+  if (/\.pdf$/i.test(new URL(candidate.url).pathname)) {
+    warnings.push(`Skipped official Salesforce PDF ${candidate.url} for ${topic.label}: PDF guides are served from the cached documentation index, not live lookup.`);
+    return null;
+  }
+  try {
+    const content = await fetchOfficialDocContent(candidate.url, SALESFORCE_DOCS_QUERY_FETCH_OPTIONS);
+    return {
+      title: content.title || candidate.title || candidate.url,
+      url: candidate.url,
+      snippet: candidate.snippet,
+      content: content.text,
+      contentQuality: content.contentQuality,
+      apiVersion: content.apiVersion,
+      releaseLabel: content.releaseLabel,
+      documentationVersion: content.documentationVersion,
+      warnings: content.warnings || [],
+    };
+  } catch (error: any) {
+    warnings.push(`Fetch failed for ${candidate.url}: ${error?.message || 'no content returned'}`);
+    return null;
+  }
+}
+
+async function resolveSalesforceDocsFallbackTopic(input: {
+  topic: SalesforceDocsTopic;
+  uid: string;
+  encryptionKeyValue: string;
+  releaseContext?: string;
+  maxResultsPerTopic: number;
+  seenSourceKeys: ReadonlySet<string>;
+  deadlineAt: number;
+}): Promise<SalesforceDocsFallbackResolution> {
+  const { topic } = input;
+  const warnings: string[] = [];
+  const rejectedUrls: string[] = [];
+  const candidates: SalesforceDocsFallbackCandidate[] = [];
+  const resolution: SalesforceDocsFallbackResolution = { topic, candidates, warnings, rejectedUrls };
+  const deadlineExceeded = () => {
+    if (Date.now() < input.deadlineAt) return false;
+    warnings.push(`Salesforce docs lookup deadline was reached before ${topic.label} could be resolved live; rerun the tool with fewer topics for live coverage.`);
+    return true;
+  };
+
+  const directTopicUrl = canonicalizeSalesforceDocsUrl(topic.query);
+  if (directTopicUrl) {
+    if (input.seenSourceKeys.has(`${topic.id}:${directTopicUrl}`)) return resolution;
+    if (deadlineExceeded()) return resolution;
+    const candidate = await fetchSalesforceDocsFallbackCandidate(topic, {
+      title: topic.label,
+      url: directTopicUrl,
+      snippet: 'Direct official Salesforce documentation reference supplied by the audit context.',
+    }, warnings);
+    if (candidate) candidates.push(candidate);
+    return resolution;
+  }
+
+  if (/^https?:\/\//i.test(topic.query.trim())) {
+    rejectedUrls.push(topic.query.trim());
+    warnings.push(`Documentation reference for ${topic.label} is not an allowed official Salesforce HTTPS URL.`);
+    return resolution;
+  }
+
+  if (deadlineExceeded()) return resolution;
+  const query = buildSalesforceDocsSearchQuery(topic, input.releaseContext);
+  let searchResponse: Awaited<ReturnType<typeof executeWebSearch>>;
+  try {
+    searchResponse = await executeWebSearch(input.uid, {
+      query,
+      num_results: Math.max(input.maxResultsPerTopic * 3, 5),
+    }, input.encryptionKeyValue);
+  } catch (error: any) {
+    warnings.push(`Search failed for ${topic.label}: ${error?.message || 'unknown search failure'}`);
+    return resolution;
+  }
+
+  const officialResults: Array<{ title: string; url: string; snippet?: string }> = [];
+  for (const result of searchResponse.results || []) {
+    const canonicalUrl = canonicalizeSalesforceDocsUrl(result.url);
+    if (!canonicalUrl) {
+      rejectedUrls.push(result.url);
+      continue;
+    }
+    if (input.seenSourceKeys.has(`${topic.id}:${canonicalUrl}`)) continue;
+    if (officialResults.some((existing) => existing.url === canonicalUrl)) continue;
+    officialResults.push({ title: result.title, url: canonicalUrl, snippet: result.snippet });
+    if (officialResults.length >= input.maxResultsPerTopic) break;
+  }
+
+  if (officialResults.length === 0) {
+    warnings.push(`No official Salesforce documentation result was found for ${topic.label}.`);
+    return resolution;
+  }
+
+  for (const result of officialResults) {
+    if (deadlineExceeded()) return resolution;
+    const candidate = await fetchSalesforceDocsFallbackCandidate(topic, result, warnings);
+    if (candidate) candidates.push(candidate);
+  }
+  return resolution;
+}
+
 async function handleSalesforceDocsLookup(
   args: SalesforceDocsLookupArgs,
   uid: string,
@@ -1147,11 +1299,18 @@ async function handleSalesforceDocsLookup(
   const sourceKey = (topicId: string, url: string) => `${topicId}:${url}`;
   let docsIndexSummary: Record<string, unknown> | undefined;
 
-  const releaseFetch = await handleFetchUrl({
-    url: SALESFORCE_RELEASES_URL,
-    includeMetadata: true,
-    maxLength: 20000,
-  });
+  const deadlineAt = startTime + SALESFORCE_DOCS_FALLBACK_DEADLINE_MS;
+  const [releaseFetch, indexLookup] = await Promise.all([
+    handleFetchUrl({
+      url: SALESFORCE_RELEASES_URL,
+      includeMetadata: true,
+      maxLength: 20000,
+    }),
+    lookupSalesforceDocsIndex(topics, {
+      generatedAt,
+      maxResultsPerTopic,
+    }),
+  ]);
   let detectedRelease: string | undefined;
   if (releaseFetch.success && releaseFetch.content) {
     const match = releaseFetch.content.match(SALESFORCE_RELEASE_LABEL_PATTERN);
@@ -1184,10 +1343,6 @@ async function handleSalesforceDocsLookup(
     warnings.push('No documentation topics were provided; Salesforce docs lookup could not ground audit claims.');
   }
 
-  const indexLookup = await lookupSalesforceDocsIndex(topics, {
-    generatedAt,
-    maxResultsPerTopic,
-  });
   warnings.push(...indexLookup.warnings);
   docsIndexSummary = indexLookup.indexSummary;
   const cachedTopicIds = new Set(
@@ -1207,95 +1362,47 @@ async function handleSalesforceDocsLookup(
     });
   }
 
-  for (const topic of topics.slice(0, 12)) {
-    if (cachedTopicIds.has(topic.id)) continue;
+  // Live fallback for topics the cached index could not satisfy, fetched via
+  // the same official-doc extraction the indexer uses (raw fetch_url gets JS
+  // shells/403s from Salesforce domains). Topics run through a small pool, but
+  // the deadline check before each network call is what actually bounds this
+  // handler under the client's 90s tool timeout — worst-case pool math alone
+  // (4 waves x (search + 2 fetches)) would exceed it.
+  const fallbackTopics = topics.slice(0, 12).filter((topic) => !cachedTopicIds.has(topic.id));
+  const seenSourceKeySnapshot: ReadonlySet<string> = new Set(seenSourceKeys);
+  const fallbackResolutions = await runWithConcurrency(
+    fallbackTopics.map((topic) => () => resolveSalesforceDocsFallbackTopic({
+      topic,
+      uid,
+      encryptionKeyValue,
+      releaseContext: args.releaseContext || detectedRelease,
+      maxResultsPerTopic,
+      seenSourceKeys: seenSourceKeySnapshot,
+      deadlineAt,
+    })),
+    SALESFORCE_DOCS_FALLBACK_CONCURRENCY,
+  );
 
-    const directTopicUrl = canonicalizeSalesforceDocsUrl(topic.query);
-    if (directTopicUrl) {
-      const key = sourceKey(topic.id, directTopicUrl);
+  for (const resolution of fallbackResolutions) {
+    warnings.push(...resolution.warnings);
+    resolution.rejectedUrls.forEach((rejectedUrl) => rejectedUrls.add(rejectedUrl));
+    for (const candidate of resolution.candidates) {
+      const key = sourceKey(resolution.topic.id, candidate.url);
       if (seenSourceKeys.has(key)) continue;
-      const fetched = await handleFetchUrl({
-        url: directTopicUrl,
-        includeMetadata: true,
-        maxLength: 30000,
-      });
-      if (!fetched.success || !fetched.content) {
-        warnings.push(`Fetch failed for ${directTopicUrl}: ${fetched.error || 'no content returned'}`);
-        continue;
-      }
-
       seenSourceKeys.add(key);
       sources.push(buildSalesforceDocEvidenceSource({
-        topic,
-        title: topic.label,
-        url: directTopicUrl,
-        snippet: 'Direct official Salesforce documentation reference supplied by the audit context.',
-        content: fetched.content,
+        topic: resolution.topic,
+        title: candidate.title,
+        url: candidate.url,
+        snippet: candidate.snippet,
+        content: candidate.content,
         retrievedAt: generatedAt,
         sourceIndex: sources.length + 1,
-      }));
-      continue;
-    }
-
-    if (/^https?:\/\//i.test(topic.query.trim())) {
-      rejectedUrls.add(topic.query.trim());
-      warnings.push(`Documentation reference for ${topic.label} is not an allowed official Salesforce HTTPS URL.`);
-      continue;
-    }
-
-    const query = buildSalesforceDocsSearchQuery(topic, args.releaseContext || detectedRelease);
-    let searchResponse: Awaited<ReturnType<typeof executeWebSearch>>;
-    try {
-      searchResponse = await executeWebSearch(uid, {
-        query,
-        num_results: Math.max(maxResultsPerTopic * 3, 5),
-      }, encryptionKeyValue);
-    } catch (error: any) {
-      warnings.push(`Search failed for ${topic.label}: ${error?.message || 'unknown search failure'}`);
-      continue;
-    }
-
-    const officialResults = [];
-    for (const result of searchResponse.results || []) {
-      const canonicalUrl = canonicalizeSalesforceDocsUrl(result.url);
-      if (!canonicalUrl) {
-        rejectedUrls.add(result.url);
-        continue;
-      }
-      if (seenSourceKeys.has(sourceKey(topic.id, canonicalUrl))) continue;
-      officialResults.push({
-        title: result.title,
-        url: canonicalUrl,
-        snippet: result.snippet,
-      });
-      if (officialResults.length >= maxResultsPerTopic) break;
-    }
-
-    if (officialResults.length === 0) {
-      warnings.push(`No official Salesforce documentation result was found for ${topic.label}.`);
-      continue;
-    }
-
-    for (const result of officialResults) {
-      const fetched = await handleFetchUrl({
-        url: result.url,
-        includeMetadata: true,
-        maxLength: 30000,
-      });
-      if (!fetched.success || !fetched.content) {
-        warnings.push(`Fetch failed for ${result.url}: ${fetched.error || 'no content returned'}`);
-        continue;
-      }
-
-      seenSourceKeys.add(sourceKey(topic.id, result.url));
-      sources.push(buildSalesforceDocEvidenceSource({
-        topic,
-        title: result.title,
-        url: result.url,
-        snippet: result.snippet,
-        content: fetched.content,
-        retrievedAt: generatedAt,
-        sourceIndex: sources.length + 1,
+        contentQuality: candidate.contentQuality,
+        apiVersion: candidate.apiVersion,
+        releaseLabel: candidate.releaseLabel,
+        documentationVersion: candidate.documentationVersion,
+        extraWarnings: candidate.warnings,
       }));
     }
   }
@@ -1561,7 +1668,7 @@ function canonicalizeSalesforceDocsUrl(urlValue: string): string | null {
     }
     url.hash = '';
     for (const key of Array.from(url.searchParams.keys())) {
-      if (/^(utm_|cmpid|d|nc|trk|mc_)/i.test(key)) {
+      if (/^(?:utm_|trk|mc_)/i.test(key) || /^(?:d|nc|cmpid)$/i.test(key)) {
         url.searchParams.delete(key);
       }
     }
@@ -1580,10 +1687,15 @@ function buildSalesforceDocEvidenceSource(input: {
   content: string;
   retrievedAt: string;
   sourceIndex: number;
+  contentQuality?: 'full_text' | 'metadata_only';
+  apiVersion?: string;
+  releaseLabel?: string;
+  documentationVersion?: string;
+  extraWarnings?: string[];
 }): SalesforceDocEvidenceSource {
   const sourceId = `sf-doc-${input.sourceIndex}`;
-  const status = inferSalesforceDocStatus(input.content);
-  const warnings = inferSalesforceDocWarnings(input.content, status);
+  const status = inferSalesforceDocumentationStatus(input.content);
+  const warnings = [...inferSalesforceDocWarnings(input.content, status), ...(input.extraWarnings || [])];
   const matchedChunks = buildSalesforceDocsMatchedChunks(input.content, input.topic.query, sourceId);
   return {
     id: sourceId,
@@ -1595,12 +1707,15 @@ function buildSalesforceDocEvidenceSource(input: {
     status,
     retrievedAt: input.retrievedAt,
     responseHash: crypto.createHash('sha256').update(input.content).digest('hex'),
-    contentQuality: 'full_text',
+    contentQuality: input.contentQuality || 'full_text',
     contentLength: input.content.length,
     excerpt: buildSalesforceDocExcerpt(input.content, input.topic.query),
     matchedChunks: matchedChunks.length > 0 ? matchedChunks : undefined,
     searchSnippet: input.snippet,
     warnings,
+    apiVersion: input.apiVersion,
+    releaseLabel: input.releaseLabel,
+    documentationVersion: input.documentationVersion,
     confidenceImpact: confidenceImpactForSalesforceEvidence(status, warnings),
   };
 }
@@ -1633,22 +1748,6 @@ function inferSalesforceDocSourceType(urlValue: string): SalesforceDocEvidenceSo
   if (url.hostname === 'help.salesforce.com') return 'help_doc';
   if (url.hostname === 'architect.salesforce.com') return 'architect_doc';
   return 'official_doc';
-}
-
-function inferSalesforceDocStatus(content: string): SalesforceDocEvidenceSource['status'] {
-  const normalized = content.replace(/\s+/g, ' ');
-  if (
-    /\b(?:developer|public|private)\s+preview\b/i.test(normalized)
-    || /\b(?:this|the)\s+(?:release|feature|document|content|functionality|release note)\s+is\s+(?:currently\s+)?(?:in\s+)?(?:preview|beta|pilot)\b/i.test(normalized)
-    || /\b(?:these|the)\s+features?\b.{0,160}\b(?:preview|beta|pilot|do not become generally available|don't become generally available|can't guarantee general availability)\b/i.test(normalized)
-    || /(?:do not|don't|can't|cannot)\s+(?:become\s+)?generally available/i.test(normalized)
-  ) {
-    return 'preview';
-  }
-  if (/generally available|\bGA\b|current release|latest release/i.test(content)) {
-    return 'ga';
-  }
-  return 'unknown';
 }
 
 function inferSalesforceDocWarnings(content: string, status: SalesforceDocEvidenceSource['status']): string[] {

--- a/functions/test/salesforceDocs.test.js
+++ b/functions/test/salesforceDocs.test.js
@@ -1,0 +1,229 @@
+const assert = require('node:assert/strict');
+const { describe, it } = require('node:test');
+const {
+  canonicalizeUrl,
+  inferSalesforceDocumentationStatus,
+  officialDocRetrievalPlan,
+  buildBm25CorpusStats,
+  bm25ChunkScore,
+  refreshCoverageError,
+} = require('../lib/salesforceDocsIndex');
+
+describe('canonicalizeUrl', () => {
+  it('strips tracking params but preserves real params starting with d/n', () => {
+    const canonical = canonicalizeUrl(
+      'https://developer.salesforce.com/page?docId=abc&deliverable=apexcode&utm_source=x&d=70130000000sdFc&nc=1&cmpid=7&trkid=9&mc_eid=4'
+    );
+    const url = new URL(canonical);
+    assert.equal(url.searchParams.get('docId'), 'abc');
+    assert.equal(url.searchParams.get('deliverable'), 'apexcode');
+    for (const stripped of ['utm_source', 'd', 'nc', 'cmpid', 'trkid', 'mc_eid']) {
+      assert.equal(url.searchParams.get(stripped), null, `expected ${stripped} to be stripped`);
+    }
+  });
+
+  it('clears fragments and lowercases the host', () => {
+    const canonical = canonicalizeUrl('https://Developer.Salesforce.com/docs/page.htm#section-3');
+    assert.equal(canonical, 'https://developer.salesforce.com/docs/page.htm');
+  });
+
+  it('rejects non-official and non-https URLs', () => {
+    assert.equal(canonicalizeUrl('https://example.com/docs'), null);
+    assert.equal(canonicalizeUrl('https://salesforce.com.evil.example/docs'), null);
+    assert.equal(canonicalizeUrl('http://developer.salesforce.com/docs/page.htm'), null);
+  });
+});
+
+describe('inferSalesforceDocumentationStatus', () => {
+  it('flags genuine preview language', () => {
+    assert.equal(
+      inferSalesforceDocumentationStatus('This feature is currently in beta and subject to change.'),
+      'preview'
+    );
+    assert.equal(
+      inferSalesforceDocumentationStatus('Available as a Developer Preview in scratch orgs.'),
+      'preview'
+    );
+    assert.equal(
+      inferSalesforceDocumentationStatus(
+        "These features are in pilot and don't become generally available unless Salesforce announces otherwise."
+      ),
+      'preview'
+    );
+  });
+
+  it('does not flag GA pages that carry safe-harbor boilerplate as preview', () => {
+    const gaPageWithSafeHarbor = [
+      "Salesforce Winter '26 Release Notes. This feature is generally available in all editions.",
+      'This document contains forward-looking statements about unreleased services or features that',
+      "don't become generally available on time or at all.",
+      'Customers should make purchase decisions based on features that are currently available.',
+    ].join(' ');
+    assert.equal(inferSalesforceDocumentationStatus(gaPageWithSafeHarbor), 'ga');
+  });
+
+  it('classifies GA and neutral text', () => {
+    assert.equal(inferSalesforceDocumentationStatus('This feature is generally available.'), 'ga');
+    assert.equal(inferSalesforceDocumentationStatus('Use SOQL to query records in Apex.'), 'unknown');
+  });
+});
+
+describe('officialDocRetrievalPlan', () => {
+  const atlasUrl = 'https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_gov_limits.htm';
+  const releaseNotesUrl = 'https://help.salesforce.com/s/articleView?id=release-notes.rn_apex.htm&language=en_US&type=5';
+  const helpArticleUrl = 'https://help.salesforce.com/s/articleView?id=sf.flow_concepts.htm&type=5';
+
+  it('routes atlas developer docs through the JSON API', () => {
+    assert.equal(officialDocRetrievalPlan(atlasUrl), 'developer_api');
+    assert.equal(officialDocRetrievalPlan(atlasUrl, { allowRendering: false }), 'developer_api');
+  });
+
+  it('renders release-notes help articles only when rendering is allowed', () => {
+    assert.equal(officialDocRetrievalPlan(releaseNotesUrl), 'rendered_help');
+    assert.equal(officialDocRetrievalPlan(releaseNotesUrl, { allowRendering: false }), 'help_metadata');
+  });
+
+  it('serves other help articles as metadata and everything else as raw HTML', () => {
+    assert.equal(officialDocRetrievalPlan(helpArticleUrl), 'help_metadata');
+    assert.equal(
+      officialDocRetrievalPlan('https://developer.salesforce.com/docs/platform/lwc/guide/apex-security.html'),
+      'raw_html'
+    );
+    assert.equal(
+      officialDocRetrievalPlan('https://architect.salesforce.com/decision-guides/trigger-automation'),
+      'raw_html'
+    );
+  });
+});
+
+describe('BM25 chunk scoring', () => {
+  function statsWith(totalChunks, avgChunkLength) {
+    return { totalChunks, avgChunkLength, dfByToken: new Map() };
+  }
+
+  it('computes corpus stats in one pass over index chunks', () => {
+    const index = {
+      records: [
+        { textChunks: [{ text: 'a'.repeat(100), contentLength: 100 }, { text: 'b'.repeat(300), contentLength: 300 }] },
+        { textChunks: [{ text: 'c'.repeat(200), contentLength: 200 }] },
+        {},
+      ],
+    };
+    const stats = buildBm25CorpusStats(index);
+    assert.equal(stats.totalChunks, 3);
+    assert.equal(stats.avgChunkLength, 200);
+    assert.equal(stats.dfByToken.size, 0);
+  });
+
+  it('weights rare tokens above common tokens', () => {
+    const stats = statsWith(100, 100);
+    const text = 'apex governor limits apply to synchronous transactions';
+    const rare = bm25ChunkScore(text, text.length, ['governor'], stats, () => 2);
+    const common = bm25ChunkScore(text, text.length, ['governor'], stats, () => 90);
+    assert.ok(rare > common, `expected rare-token score ${rare} > common-token score ${common}`);
+  });
+
+  it('saturates term frequency', () => {
+    const stats = statsWith(100, 60);
+    const once = 'governor limits apply here in this transaction context and elsewhere';
+    const fourTimes = 'governor governor governor governor limits apply in transaction context';
+    const scoreOnce = bm25ChunkScore(once, once.length, ['governor'], stats, () => 5);
+    const scoreFour = bm25ChunkScore(fourTimes, fourTimes.length, ['governor'], stats, () => 5);
+    assert.ok(scoreFour > scoreOnce, 'more occurrences must score higher');
+    assert.ok(scoreFour < scoreOnce * 4, 'term frequency must saturate, not scale linearly');
+  });
+
+  it('normalizes for chunk length', () => {
+    const stats = statsWith(100, 100);
+    const shortText = 'governor limits';
+    const longText = `governor limits ${'padding '.repeat(60)}`;
+    const shortScore = bm25ChunkScore(shortText, 50, ['governor'], stats, () => 5);
+    const longScore = bm25ChunkScore(longText, 400, ['governor'], stats, () => 5);
+    assert.ok(shortScore > longScore, 'same tf in a shorter chunk must score higher');
+  });
+
+  it('returns 0 on an empty corpus', () => {
+    assert.equal(bm25ChunkScore('governor', 8, ['governor'], statsWith(0, 0), () => 0), 0);
+  });
+});
+
+describe('refreshCoverageError', () => {
+  function makeRecord(overrides = {}) {
+    return {
+      id: 'r',
+      topicIds: ['apex-governor-limits'],
+      title: 'Doc',
+      url: 'https://developer.salesforce.com/docs/page.htm',
+      domain: 'developer.salesforce.com',
+      sourceType: 'developer_doc',
+      status: 'ga',
+      retrievedAt: new Date().toISOString(),
+      responseHash: 'hash',
+      contentQuality: 'full_text',
+      contentLength: 1000,
+      excerpt: 'excerpt',
+      keywords: [],
+      warnings: [],
+      discoverySource: 'seed',
+      confidenceImpact: 'supports',
+      ...overrides,
+    };
+  }
+
+  function makeIndex(records) {
+    return {
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      sourcePolicy: { allowedHostPattern: '*.salesforce.com', storagePath: 'salesforce-docs/index-v1.json' },
+      topics: [],
+      records,
+      failures: [],
+      warnings: [],
+    };
+  }
+
+  const passingRecords = [
+    ...Array.from({ length: 120 }, (_, i) => makeRecord({ id: `dev-${i}` })),
+    ...Array.from({ length: 12 }, (_, i) => makeRecord({
+      id: `pdf-${i}`,
+      domain: 'resources.docs.salesforce.com',
+      sourceType: 'pdf_guide',
+      sourceFormat: 'pdf',
+    })),
+  ];
+
+  it('accepts an index meeting all gates', () => {
+    assert.equal(refreshCoverageError(makeIndex(passingRecords)), null);
+  });
+
+  it('rejects too few developer.salesforce.com records', () => {
+    const records = passingRecords.map((record, i) =>
+      i < 60 ? { ...record, domain: 'help.salesforce.com' } : record
+    );
+    assert.match(refreshCoverageError(makeIndex(records)), /developer\.salesforce\.com/);
+  });
+
+  it('rejects too few full-text records', () => {
+    const records = passingRecords.map((record) => ({ ...record, contentLength: 100 }));
+    assert.match(refreshCoverageError(makeIndex(records)), /full-text/);
+  });
+
+  it('rejects too few PDF records', () => {
+    const records = passingRecords.map((record) =>
+      record.sourceFormat === 'pdf' && record.id !== 'pdf-0' ? { ...record, sourceFormat: 'html' } : record
+    );
+    assert.match(refreshCoverageError(makeIndex(records)), /PDF record/);
+  });
+
+  it('rejects a metadata-only ratio above the ceiling', () => {
+    const records = [
+      ...passingRecords,
+      ...Array.from({ length: 8 }, (_, i) => makeRecord({
+        id: `meta-${i}`,
+        contentQuality: 'metadata_only',
+        contentLength: 120,
+      })),
+    ];
+    assert.match(refreshCoverageError(makeIndex(records)), /metadata-only ratio/);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1677,9 +1677,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1758,9 +1758,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4351,9 +4351,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -4629,9 +4629,9 @@
       "license": "MIT"
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5122,9 +5122,9 @@
       "license": "MIT"
     },
     "node_modules/@react-native/babel-plugin-codegen/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5251,9 +5251,9 @@
       "license": "MIT"
     },
     "node_modules/@react-native/codegen/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6838,15 +6838,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -8385,9 +8385,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8446,9 +8446,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11140,9 +11140,9 @@
       "license": "MIT"
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11593,9 +11593,9 @@
       "license": "MIT"
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11905,9 +11905,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -13352,9 +13352,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -14211,9 +14211,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -14230,7 +14230,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -15201,9 +15201,9 @@
       "license": "MIT"
     },
     "node_modules/react-native/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -15653,9 +15653,9 @@
       "license": "MIT"
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -16758,9 +16758,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",


### PR DESCRIPTION
## Summary

Quality fixes for the Salesforce docs lookup system, from the 2026-08-07 review. Approved scope: core fixes + BM25 + tests.

- **Live fallback now actually works.** Off-index topics were fetched with `handleFetchUrl`, which gets JS shells and 403s from Salesforce domains — so anything outside the ~45 curated topics produced junk evidence. The fallback now routes through the same official-doc extraction the indexer uses (`fetchOfficialDocContent`: dev-docs JSON API → help metadata → raw HTML), with headless-Chrome rendering gated to index builds only. This effectively extends real coverage to any developer.salesforce.com page web search can surface.
- **Fallback is parallel and deadline-bounded.** Per-topic resolution runs through a pool of 3 under a 70s deadline (checked before each network call) so the handler stays inside the client's 90s tool timeout even on a stale/missing index. Release-context fetch and index lookup now run concurrently.
- **Index reads are cached and writes minified.** The parsed multi-MB index is held in module scope (in-flight promise cache + 5min TTL + GCS generation revalidation) instead of being re-downloaded and re-parsed per lookup. Both `writeSalesforceDocsIndex` and the local script's gcloud upload path now store minified JSON.
- **BM25 chunk ranking** replaces flat substring counting (`+2/+4 per includes()`): lazy memoized document frequency per index generation, k1=1.2 / b=0.75, scaled into the existing 0–80 chunk band. Alias-topic bonus rebalanced 100→40 (and alias+dev-doc 30→15) so content relevance can compete with topic routing.
- **Canonicalize regex bug** (both copies): `/^(utm_|cmpid|d|nc|trk|mc_)/` was prefix-anchored only, stripping ANY query param starting with `d` or `nc` (`docId`, `deliverable`, …). Now prefix-match for `utm_/trk/mc_`, exact-match for `d/nc/cmpid`. Canonical record URLs shift on the next index rebuild — harmless, the index regenerates wholesale.
- **Safe-harbor guard**: forward-looking-statements boilerplate on GA release-notes pages no longer flags whole documents as `preview` (which systematically confidence-downgraded findings). The duplicated status matcher in tools.ts is deleted in favor of one exported `inferSalesforceDocumentationStatus`.
- **First server-side tests** for this subsystem: canonicalization, status inference (incl. the safe-harbor false-positive case), retrieval-plan routing, BM25 sanity (idf/tf-saturation/length-norm), and the refresh coverage gates.

## Test plan

- [x] `npm test` in functions — 71 tests green (19 new in `test/salesforceDocs.test.js`)
- [x] `tsc --noEmit` clean
- [ ] Post-deploy live smoke: off-index topic (e.g. "OmniStudio DataRaptor bulk limits") returns full_text developer.salesforce.com sources; consecutive lookups hit the index cache; latency well under 90s

Follow-up (separate PR, symposium-ai-web): delete the client-side live-lookup fallback that this server path obsoletes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)