### PR TITLE
fix(salesforce-docs): weak index matches no longer suppress live fallback

### DIFF
--- a/functions/src/salesforceDocsIndex.ts
+++ b/functions/src/salesforceDocsIndex.ts
@@ -253,6 +253,13 @@ export interface SalesforceDocsIndexEvidenceSource {
 export interface SalesforceDocsIndexLookupResult {
   sources: SalesforceDocsIndexEvidenceSource[];
   topicHits: string[];
+  /**
+   * Topics whose selected records belong to an indexed topic this lookup topic
+   * aliases to — i.e. the index genuinely curates them. Topics that only
+   * scavenged token-overlap matches are NOT listed here, and callers must not
+   * let those weak hits suppress live lookup.
+   */
+  aliasRoutedTopicIds: string[];
   warnings: string[];
   indexSummary?: {
     status: 'hit' | 'miss' | 'unavailable' | 'stale';
@@ -2976,6 +2983,13 @@ function scoreRecordForTopic(
   return Math.max(0, score);
 }
 
+export function selectionIsAliasRouted(
+  records: Array<Pick<SalesforceDocsIndexRecord, 'topicIds'>>,
+  aliasTopicIds: string[],
+): boolean {
+  return records.some((record) => record.topicIds.some((topicId) => aliasTopicIds.includes(topicId)));
+}
+
 function selectScoredRecordsForTopic(
   scored: Array<{ record: SalesforceDocsIndexRecord; score: number }>,
   aliasTopicIds: string[],
@@ -3016,6 +3030,7 @@ export async function lookupSalesforceDocsIndex(
     return {
       sources: [],
       topicHits: [],
+      aliasRoutedTopicIds: [],
       warnings: [`Salesforce documentation index is unavailable at ${SALESFORCE_DOC_INDEX_PATH}; falling back to live official-source lookup.`],
       indexSummary: {
         status: 'unavailable',
@@ -3049,6 +3064,7 @@ export async function lookupSalesforceDocsIndex(
 
   const sources: SalesforceDocsIndexEvidenceSource[] = [];
   const topicHits = new Set<string>();
+  const aliasRoutedTopicIds = new Set<string>();
   const topicSourceCounts = new Map<string, number>();
   const seenSourceKeys = new Set<string>();
 
@@ -3064,6 +3080,9 @@ export async function lookupSalesforceDocsIndex(
 
     if (selected.length === 0) continue;
     topicHits.add(topic.id);
+    if (selectionIsAliasRouted(selected.map((item) => item.record), aliasTopicIds)) {
+      aliasRoutedTopicIds.add(topic.id);
+    }
     topicSourceCounts.set(topic.id, selected.length);
 
     for (const item of selected) {
@@ -3115,6 +3134,7 @@ export async function lookupSalesforceDocsIndex(
   return {
     sources,
     topicHits: Array.from(topicHits),
+    aliasRoutedTopicIds: Array.from(aliasRoutedTopicIds),
     warnings,
     indexSummary: {
       status: sources.length > 0

--- a/functions/src/tools.ts
+++ b/functions/src/tools.ts
@@ -1345,11 +1345,17 @@ async function handleSalesforceDocsLookup(
 
   warnings.push(...indexLookup.warnings);
   docsIndexSummary = indexLookup.indexSummary;
+  // Only alias-routed hits (topics the index genuinely curates) may suppress
+  // live lookup. Token-scavenged matches keep their index sources as
+  // supplementary evidence, but the topic still goes to live fallback —
+  // otherwise a tangential "bulk"/"limits" overlap blocks real coverage.
+  const aliasRoutedTopicIds = new Set(indexLookup.aliasRoutedTopicIds || []);
   const cachedTopicIds = new Set(
     indexLookup.indexSummary?.status === 'hit'
       ? indexLookup.sources
         .filter((source) => source.confidenceImpact !== 'stale-risk')
         .map((source) => source.topicId)
+        .filter((topicId) => aliasRoutedTopicIds.has(topicId))
       : []
   );
   for (const source of indexLookup.sources) {

--- a/functions/test/salesforceDocs.test.js
+++ b/functions/test/salesforceDocs.test.js
@@ -7,7 +7,24 @@ const {
   buildBm25CorpusStats,
   bm25ChunkScore,
   refreshCoverageError,
+  selectionIsAliasRouted,
 } = require('../lib/salesforceDocsIndex');
+
+describe('selectionIsAliasRouted', () => {
+  it('routes only when a selected record belongs to an aliased indexed topic', () => {
+    const aliasIds = ['apex-governor-limits', 'soql-query-selectivity'];
+    assert.equal(
+      selectionIsAliasRouted([{ topicIds: ['flow-fault-paths'] }, { topicIds: ['apex-governor-limits'] }], aliasIds),
+      true
+    );
+    assert.equal(
+      selectionIsAliasRouted([{ topicIds: ['flow-fault-paths'] }, { topicIds: ['lightning-security'] }], aliasIds),
+      false,
+      'token-scavenged selections must not count as alias-routed'
+    );
+    assert.equal(selectionIsAliasRouted([], aliasIds), false);
+  });
+});
 
 describe('canonicalizeUrl', () => {
   it('strips tracking params but preserves real params starting with d/n', () => {


### PR DESCRIPTION
## Summary

Follow-up to #152, from its live smoke test: the off-index live fallback never fired in practice because token-scavenged index matches (e.g. generic Apex bulk/limits docs matching an OmniStudio DataRaptor topic on the tokens "bulk"/"limits") marked topics as cache hits and suppressed live lookup.

- `lookupSalesforceDocsIndex` now returns `aliasRoutedTopicIds` — topics whose selected records belong to an indexed topic the lookup topic aliases to (i.e. genuinely curated coverage).
- The `handleSalesforceDocsLookup` gate only lets alias-routed hits suppress the live fallback. Scavenged hits keep their index sources as supplementary evidence, and the topic still resolves live through `fetchOfficialDocContent`.

## Test plan

- [x] `npm test` — 72 green (new `selectionIsAliasRouted` fixtures)
- [x] `tsc` clean via build
- [ ] Post-deploy live smoke: OmniStudio DataRaptor topic returns OmniStudio docs from the live path alongside any index sources; alias-routed topics (e.g. apex-governor-limits) still skip live work

🤖 Generated with [Claude Code](https://claude.com/claude-code)